### PR TITLE
Add generic templates to describe YUM repositories for Quattor repositories

### DIFF
--- a/repository/config/quattor.pan
+++ b/repository/config/quattor.pan
@@ -13,11 +13,32 @@ include { 'quattor/functions/repository' };
 # QUATTOR_REPOSITORY_RELEASE allows to define the Quattor release repository to use, in case
 # there is no repository specific to the release
 variable QUATTOR_REPOSITORY_RELEASE ?= QUATTOR_RELEASE;
+# First try a template specific to the release if it exists, else use a generic one
+# for 14.6+ or the release specific one before.
+@{
+desc = repository template describing YUM repository to use for the Quattor release
+values = a templane name with the 'repository/' namespace ommitted
+default = generic repository template appropriate
+required = no
+}
+variable QUATTOR_REPOSITORY_TEMPLATE ?= if ( is_defined(if_exists('repository/quattor_'+QUATTOR_REPOSITORY_RELEASE)) ) {
+                                          'quattor_'+QUATTOR_REPOSITORY_RELEASE;
+                                        };
+variable QUATTOR_REPOSITORY_TEMPLATE ?= if ( is_defined(QUATTOR_RELEASE) && ((QUATTOR_RELEASE >= '15') || match(QUATTOR_RELEASE,'^14\.[1689]')) ) {
+                                          if ( match(QUATTOR_RELEASE,'-rc\d+$') ) {
+                                            'quattor_rc';
+                                          } else {
+                                            'quattor';
+                                          };
+                                        } else {
+                                          'quattor_' + QUATTOR_REPOSITORY_RELEASE;
+                                        };
+variable QUATTOR_REPOSITORY_TEMPLATE ?= 'quattor_' + QUATTOR_REPOSITORY_RELEASE;
 variable QUATTOR_REPOSITORY_LIST ?= if ( is_defined(QUATTOR_RELEASE) ) {
                                       if ( match(QUATTOR_RELEASE,'13\.1') && (QUATTOR_RELEASE != '13.12') ) {
-                                        repos = list('quattor_'+QUATTOR_REPOSITORY_RELEASE,'quattor_externals','quattor_components');
+                                        repos = list(QUATTOR_REPOSITORY_TEMPLATE,'quattor_externals','quattor_components');
                                       } else {
-                                        repos = list('quattor_'+QUATTOR_REPOSITORY_RELEASE,'quattor_externals');
+                                        repos = list(QUATTOR_REPOSITORY_TEMPLATE,'quattor_externals');
                                       };
                                       debug("Repositories added for Quattor release "+QUATTOR_RELEASE+": "+to_string(repos));
                                       repos;

--- a/repository/quattor.pan
+++ b/repository/quattor.pan
@@ -1,0 +1,11 @@
+# Template allowing to create the repository appropriate for Quattor releases
+
+structure template repository/quattor;
+
+"name" = 'quattor_' + QUATTOR_REPOSITORY_RELEASE;
+"owner" = "quattor-grid@lists.sourceforge.net";
+"protocols" = list(
+  nlist("name","http",
+        "url","http://yum.quattor.org/"+QUATTOR_REPOSITORY_RELEASE)
+);
+

--- a/repository/quattor_rc.pan
+++ b/repository/quattor_rc.pan
@@ -1,0 +1,11 @@
+# Template allowing to create the repository appropriate for Quattor release candidates
+
+structure template repository/quattor_rc;
+
+"name" = 'quattor_' + QUATTOR_REPOSITORY_RELEASE;
+"owner" = "quattor-grid@lists.sourceforge.net";
+"protocols" = list(
+  nlist("name","http",
+        "url","http://yum.quattor.org/testing/"+QUATTOR_REPOSITORY_RELEASE)
+);
+


### PR DESCRIPTION
- These templates point to standard Quattor YUM repos on `yum.quattor.org` (as snapshotting them doesn't really make sense).
- Use them by default if no release-specific repo template exists
- Add variable `QUATTOR_REPOSITORY_TEMPLATE` to allow a site to override defaults, if needed.
