### PR TITLE
Fix inclusion of pakiti config

### DIFF
--- a/features/pakiti/client/config.pan
+++ b/features/pakiti/client/config.pan
@@ -1,8 +1,8 @@
 unique template features/pakiti/client/config;
 
-variable PAKITI_RPMS ?= if_exists('config/pakiti/client/config');
+include if_exists('config/pakiti/client/config');
 variable PAKITI_RPMS ?= 'features/pakiti/client/rpms';
-include { PAKITI_RPMS };
+include PAKITI_RPMS;
 
 variable pakiti_conf = "servers_name = "+PAKITI_SERVER+":"+PAKITI_SERVER_PORT+"\n";
 variable pakiti_conf = pakiti_conf+"server_url = "+PAKITI_SERVER_URL+"\n";


### PR DESCRIPTION
This ensures that both the config and the RPMs are included, which wasn't the case before.
Fixes #28.
