### PR TITLE
perfSonar: fix generation of script used to configure perfSonar ports

### DIFF
--- a/personality/perfsonar-ps/config.pan
+++ b/personality/perfsonar-ps/config.pan
@@ -20,7 +20,7 @@ variable PERFSONAR_PORTS_DEFAULT ?= nlist(
         'owamp_port', '5601:5900',
     ),
     'OWAMP', nlist(
-        'testports', '8760:8960',
+        'testports', '8760:9960',
     ),
 );
 


### PR DESCRIPTION
Fix committed 5 mn too late to be part of #38! Can probably wait next RC as I'm finalizing the troubleshooting of our new 3.4 instance. Seems ok now but better to wait a few hours/days...
