### PR TITLE
Do not install cvmfs-keys with cvmfs

### DIFF
--- a/features/cvmfs/rpms.pan
+++ b/features/cvmfs/rpms.pan
@@ -1,4 +1,3 @@
 unique template features/cvmfs/rpms;
 
-'/software/packages/{cvmfs}' ?= nlist();
-'/software/packages/{cvmfs-keys}' ?= nlist();
+'/software/packages/{cvmfs}' ?= dict();


### PR DESCRIPTION
cvmfs-keys has been replaced by cvmfs-config-default which is a dependency of cvmfs.
Also replace nlist with dict.

Fixes #56