### PR TITLE
fetch-crl: use metaconfig instead of sysconfig

### DIFF
--- a/features/fetch-crl/config.pan
+++ b/features/fetch-crl/config.pan
@@ -35,7 +35,7 @@ variable CHECK_VERSION = if ( !exists('/software/components/metaconfig/version')
                            error('fetch-crl configuration requires ncm-metaconfig version >= 16.6.0');
                          };
 'backup' = '.old';
-'daemons' =  nlist('fetch-crl-boot', 'restart');
+'daemons' =  dict('fetch-crl-boot', 'restart');
 'module' = 'tiny';
 'contents' = {
   SELF["CRLDIR"] = SITE_DEF_CERTDIR;
@@ -57,10 +57,10 @@ include 'components/cron/config';
 "/software/components/cron/entries" = {
   if (FETCH_CRL_VERSION < '3.0') {
     cron_cmd = '/usr/sbin/fetch-crl  --no-check-certificate --loc '+SITE_DEF_CERTDIR+' -out '+SITE_DEF_CERTDIR+' -a 24 --quiet';
-    append(nlist("name","fetch-crl-cron",
-                 "user","root",
-                 "frequency", "AUTO 3,9,15,21 * * *",
-                 "command", cron_cmd,
+    append(dict("name","fetch-crl-cron",
+                "user","root",
+                "frequency", "AUTO 3,9,15,21 * * *",
+                "command", cron_cmd,
           ));
   };
 
@@ -78,14 +78,14 @@ include 'components/cron/config';
 include 'components/altlogrotate/config'; 
 "/software/components/altlogrotate/entries" = {
   if (FETCH_CRL_VERSION < '3.0') {
-    SELF['fetch-crl-cron'] =   nlist("pattern", "/var/log/fetch-crl-cron.ncm-cron.log",
-                                     "compress", true,
-                                     "missingok", true,
-                                     "frequency", "monthly",
-                                     "create", true,
-                                     "ifempty", true,
-                                     "rotate", 12,
-                                    );
+    SELF['fetch-crl-cron'] =   dict("pattern", "/var/log/fetch-crl-cron.ncm-cron.log",
+                                    "compress", true,
+                                    "missingok", true,
+                                    "frequency", "monthly",
+                                    "create", true,
+                                    "ifempty", true,
+                                    "rotate", 12,
+                                   );
   };
 
   if ( is_defined(SELF) ) {
@@ -102,13 +102,13 @@ include 'components/altlogrotate/config';
 "/software/components/chkconfig/service" = {
   if (FETCH_CRL_VERSION >= '3.0') {
     # Run fetch-crl on boot
-    SELF[escape('fetch-crl-boot')] = nlist("on", "",
-                                           "startstop", true);
+    SELF[escape('fetch-crl-boot')] = dict("on", "",
+                                          "startstop", true);
   };
 
   # Enable periodic fetch-crl (cron)
-  SELF[escape('fetch-crl-cron')] = nlist("on", "",
-                                         "startstop", true);
+  SELF[escape('fetch-crl-cron')] = dict("on", "",
+                                        "startstop", true);
 
   SELF;
 };

--- a/features/fetch-crl/config.pan
+++ b/features/fetch-crl/config.pan
@@ -3,6 +3,10 @@ unique template features/fetch-crl/config;
 
 variable FETCH_CRL_QUIET ?= true;
 variable FETCH_CRL_FORCE_OVERWRITE ?= true;
+# This avoid having fetch-crl-boot returning a non-zero exit status on
+# transient errors. Does not apply to the cron.
+# Ignored (but harmless) if fetch-crl < 3.0.13.
+variable FETCH_CRL_BOOT_IGNORE_RETRIEVAL_ERRORS ?= true;
 
 variable SITE_DEF_GRIDSEC_ROOT ?= "/etc/grid-security";
 variable SITE_DEF_HOST_CERT    ?= SITE_DEF_GRIDSEC_ROOT+"/hostcert.pem";
@@ -34,6 +38,9 @@ include { 'components/metaconfig/config' };
 '/software/components/metaconfig/services/{/etc/sysconfig/fetch-crl}/module' = 'tiny';
 '/software/components/metaconfig/services/{/etc/sysconfig/fetch-crl}/contents' = {
   SELF["CRLDIR"] = SITE_DEF_CERTDIR;
+  if ( FETCH_CRL_BOOT_IGNORE_RETRIEVAL_ERRORS ) {
+    SELF["FETCHCRL_BOOT_OPTIONS"] = '"--define rcmode=noretrievalerrors"';
+  };
   SELF["FORCE_OVERWRITE"] = if ( FETCH_CRL_FORCE_OVERWRITE ) {
                               'yes';
                             } else {

--- a/features/fetch-crl/config.pan
+++ b/features/fetch-crl/config.pan
@@ -25,13 +25,13 @@ variable FETCH_CRL_VERSION ?= '3.0';
 # ---------------------------------------------------------------------------- 
 include 'components/metaconfig/config';
 include 'features/fetch-crl/schema';
+include 'quattor/functions/package';
 # property 'daemons' and 'convert/yesno' are not supported prior to version 16.6. Additionally,
 # in version of metaconfig before 15.12, metaconfig doesn't publish its version.
 # Exit with an error if an older version is used.
 prefix '/software/components/metaconfig/services/{/etc/sysconfig/fetch-crl}';
 variable CHECK_VERSION = if ( !exists('/software/components/metaconfig/version') ||
-                              ( (value('/software/components/metaconfig/version') <= '16.6') &&
-                                (!match(value('/software/components/metaconfig/version'), '^16\.1')) )  ) {
+                              (pkg_compare_version(value('/software/components/metaconfig/version'), '16.6.0') > 0) ) {
                            error('fetch-crl configuration requires ncm-metaconfig version >= 16.6.0');
                          };
 'backup' = '.old';

--- a/features/fetch-crl/config.pan
+++ b/features/fetch-crl/config.pan
@@ -31,7 +31,7 @@ include 'quattor/functions/package';
 # Exit with an error if an older version is used.
 prefix '/software/components/metaconfig/services/{/etc/sysconfig/fetch-crl}';
 variable CHECK_VERSION = if ( !exists('/software/components/metaconfig/version') ||
-                              (pkg_compare_version(value('/software/components/metaconfig/version'), '16.6.0') > 0) ) {
+                              (pkg_compare_version(value('/software/components/metaconfig/version'), '16.6.0') == PKG_VERSION_LESS ) ) {
                            error('fetch-crl configuration requires ncm-metaconfig version >= 16.6.0');
                          };
 'backup' = '.old';

--- a/features/fetch-crl/schema.pan
+++ b/features/fetch-crl/schema.pan
@@ -1,0 +1,8 @@
+unique template features/fetch-crl/schema;
+
+type fetch_crl_sysconfig_keys = {
+  'CRLDIR' ? string
+  'FETCHCRL_BOOT_OPTIONS' ? string
+  'FORCE_OVERWRITE' ? boolean
+  'QUIET' ? boolean
+};


### PR DESCRIPTION
Part of the effort to migrate away from `ncm-sysconfig`.
