### PR TITLE
Use pkg_compare_version to compare CVMFS client versions

### DIFF
--- a/features/cvmfs/client.pan
+++ b/features/cvmfs/client.pan
@@ -97,8 +97,9 @@ include { 'repository/config/cvmfs' };
 #
 # Enable service
 #
+include 'quattor/functions/package';
 '/software/components/chkconfig/service' = {
-    if (CVMFS_CLIENT_VERSION < '2.1' && ! is_defined(SELF['cvmfs'])) {
+    if ((pkg_compare_version('2.1', CVMFS_CLIENT_VERSION) == -1) && ! is_defined(SELF['cvmfs'])) {
         SELF['cvmfs'] = nlist('on', '', 'startstop', false);
     };
     SELF;


### PR DESCRIPTION
The previous code used a numerical comparison on strings, with incorrect results.

Fixes #59.

Tested, but impact of change on existing systems is unknown.