### PR TITLE
Set required RPMs accordingly to cvmfs version

### DIFF
--- a/features/cvmfs/rpms.pan
+++ b/features/cvmfs/rpms.pan
@@ -1,3 +1,14 @@
 unique template features/cvmfs/rpms;
 
 '/software/packages/{cvmfs}' ?= dict();
+
+include 'quattor/functions/package';
+
+'/software/packages' = {
+  if ((pkg_compare_version(CVMFS_CLIENT_VERSION, '2.1.20') <= 0) && (OS_VERSION_PARAMS['major'] != 'sl5')) {
+    SELF[escape('cvmfs-config-default')] = dict();
+  } else {
+    SELF[escape('cvmfs-keys')] = dict();
+  };
+  SELF;
+};


### PR DESCRIPTION
Fix the RPM to install when the client is 2.1.20. See:
http://cernvm.cern.ch/portal/filesystem/cvmfs-2.1.20