### PR TITLE
Add directories under hardware/nic/ for each nic manufacturer.

### DIFF
--- a/hardware/nic/3c59x.pan
+++ b/hardware/nic/3c59x.pan
@@ -1,15 +1,4 @@
-######################################################
-#
-# template hardware/nic/3c59x;
-#
-# RESPONSIBLE: Victor Mendoza <mendoza@lpnhe.in2p3.fr>
-#
-######################################################
-
 structure template hardware/nic/3c59x;
 
-"driver" = "3c59x";
-"pxe"    = false;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "3COM 3c59x";
+include 'hardware/nic/legacy/3c59x';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/bcm5700.pan
+++ b/hardware/nic/bcm5700.pan
@@ -1,14 +1,4 @@
-######################################################
-#
-# RESPONSIBLE: Jacquelin Charbonnel <charbonnel@lal.in2p3.fr>
-#
-######################################################
-
 structure template hardware/nic/bcm5700;
 
-"driver" = "bcm5700";
-"driverrpms" = list("bcm5700", "bcm5700-smp");
-"pxe"    = true;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Broadcom PCI-X 10/100/1000BASE-T Controller";
+include 'hardware/nic/legacy/bcm5700';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/be2net.pan
+++ b/hardware/nic/be2net.pan
@@ -1,13 +1,4 @@
-######################################################
-#
-# template hardware/nic/be2net;
-#
-######################################################
-
 structure template hardware/nic/be2net;
 
-"driver" = "be2net";
-"pxe"    = true;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Emulex OneConnect 10Gb NIC";
+include 'hardware/nic/legacy/be2net';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/bnx2.pan
+++ b/hardware/nic/bnx2.pan
@@ -1,15 +1,4 @@
-######################################################
-#
-# template hardware/nic/bnx2;
-#
-# RESPONSIBLE: Victor Mendoza <mendoza@lpnhe.in2p3.fr>
-#
-######################################################
-
 structure template hardware/nic/bnx2;
 
-"driver" = "bnx2";
-"pxe"    = true;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Broadcom NetXtreme II";
+include 'hardware/nic/legacy/bnx2';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/bnx2x.pan
+++ b/hardware/nic/bnx2x.pan
@@ -1,13 +1,4 @@
-######################################################
-#
-# template hardware/nic/bnx2x;
-#
-######################################################
-
 structure template hardware/nic/bnx2x;
 
-"driver" = "bnx2x";
-"pxe"    = true;
-"boot"   = true;
-"media"  = "Ethernet";
-"name"   = "Broadcom NetXtreme II BCM57711 10-Gigabit PCIe";
+include 'hardware/nic/legacy/bnx2x';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/broadcom/bcm5700.pan
+++ b/hardware/nic/broadcom/bcm5700.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/broadcom/bcm5700;
+
+'model' = 'bcm5700';
+'manufacturer' = 'broadcom';
+'driver' = 'bcm5700';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Broadcom PCI-X 10/100/1000BASE-T Controller';
+'maxspeed' = 1000;

--- a/hardware/nic/broadcom/bcm5709.pan
+++ b/hardware/nic/broadcom/bcm5709.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/broadcom/bcm5709;
+
+'model' = 'bcm5709';
+'manufacturer' = 'broadcom';
+'driver' = 'bnx2';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Broadcom Corporation NetXtreme II BCM5709 Gigabit Ethernet';
+'maxspeed' = 1000;

--- a/hardware/nic/broadcom/bcm5716.pan
+++ b/hardware/nic/broadcom/bcm5716.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/broadcom/bcm5716;
+
+'model' = 'bcm5716';
+'manufacturer' = 'broadcom';
+'driver' = 'bnx2';
+'pxe' = flase;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Broadcom Corporation NetXtreme II BCM5716 Gigabit Ethernet';
+'maxspeed' = 1000;

--- a/hardware/nic/broadcom/bcm5719.pan
+++ b/hardware/nic/broadcom/bcm5719.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/broadcom/bcm5719;
+
+'model' = 'bcm5719';
+'manufacturer' = 'broadcom';
+'driver' = 'tg3';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Broadcom Corporation NetXtreme BCM5719 Gigabit Ethernet PCIe';
+'maxspeed' = 1000;

--- a/hardware/nic/broadcom/bcm5720.pan
+++ b/hardware/nic/broadcom/bcm5720.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/broadcom/bcm5720;
+
+'model' = 'bcm5720';
+'manufacturer' = 'broadcom';
+'driver' = 'tg3';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Broadcom Corporation NetXtreme BCM5720 Gigabit Ethernet PCIe';
+'maxspeed' = 1000;

--- a/hardware/nic/broadcom/bcm57711.pan
+++ b/hardware/nic/broadcom/bcm57711.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/broadcom/bcm57711;
+
+'model' = 'bcm57711';
+'manufacturer' = 'broadcom';
+'driver' = 'bnx2x';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Broadcom Corporation NetXtreme II BCM57711 10-Gigabit PCIe';
+'maxspeed' = 10000;

--- a/hardware/nic/deprecation-warning.pan
+++ b/hardware/nic/deprecation-warning.pan
@@ -1,0 +1,3 @@
+structure template hardware/nic/deprecation-warning;
+
+'type' = { deprecated(0, 'Use of nic templates immediately under hardware/nic/ is deprecated. Please use templates under hardware/nic/nic_manufacturer/ instead.'); 'deprecated' };

--- a/hardware/nic/e100.pan
+++ b/hardware/nic/e100.pan
@@ -1,8 +1,4 @@
-
 structure template hardware/nic/e100;
 
-"driver" = "intelpro100";
-"pxe"    = false;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Intel 82555 10/100 Megabit card";
+include 'hardware/nic/legacy/e100';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/e1000.pan
+++ b/hardware/nic/e1000.pan
@@ -1,16 +1,4 @@
-######################################################
-#
-# from template pro_hardware_card_nic_e1000;
-#
-# RESPONSIBLE: Charles Loomis <charles.loomis@cern.ch>
-#
-######################################################
-
 structure template hardware/nic/e1000;
 
-"driver" = "e1000";
-"pxe"    = false;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Intel e1000 Gigabit card";
-"maxspeed" = 1000;
+include 'hardware/nic/legacy/e1000';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/e1000e.pan
+++ b/hardware/nic/e1000e.pan
@@ -1,8 +1,4 @@
 structure template hardware/nic/e1000e;
 
-"driver" = "e1000e";
-"pxe"    = false;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Intel e1000 Gigabit card";
-"maxspeed" = 1000;
+include 'hardware/nic/legacy/e1000e';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/igb.pan
+++ b/hardware/nic/igb.pan
@@ -1,15 +1,4 @@
-######################################################
-#
-# from template hardware/nic/igb;
-#
-# RESPONSIBLE: Christophe DIARRA
-#
-######################################################
-
 structure template hardware/nic/igb;
 
-"driver" = "igb";
-"pxe"    = false;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Intel 82575/6 and 82580-Based Gigabit Network";
+include 'hardware/nic/legacy/igb';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/intel/82574l.pan
+++ b/hardware/nic/intel/82574l.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/intel/82574l;
+
+'model' = '82574l';
+'manufacturer' = 'intel';
+'driver' = 'e1000e';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Intel Corporation 82574L Gigabit Network Connection';
+'maxspeed' = 1000;

--- a/hardware/nic/intel/82599eb.pan
+++ b/hardware/nic/intel/82599eb.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/intel/82599eb;
+
+'model' = '82599eb';
+'manufacturer' = 'intel';
+'driver' = 'ixgbe';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Intel Corporation 82599EB 10-Gigabit SFI/SFP+ Network Connection';
+'maxspeed' = 10000;

--- a/hardware/nic/intel/i210.pan
+++ b/hardware/nic/intel/i210.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/intel/i210;
+
+'model' = 'i210';
+'manufacturer' = 'intel';
+'driver' = 'igb';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Intel Corporation I210 Gigabit Network Connection';
+'maxspeed' = 1000;

--- a/hardware/nic/intel/i350.pan
+++ b/hardware/nic/intel/i350.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/intel/i350;
+
+'model' = 'i350';
+'manufacturer' = 'intel';
+'driver' = 'igb';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Intel Corporation I350 Gigabit Network Connection';
+'maxspeed' = 1000;

--- a/hardware/nic/intel/x520.pan
+++ b/hardware/nic/intel/x520.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/intel/x520;
+
+'model' = 'x520';
+'manufacturer' = 'intel';
+'driver' = 'ixgbe';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Intel Corporation Ethernet 10G 2P X520 Adapter';
+'maxspeed' = 10000;

--- a/hardware/nic/ixgbe.pan
+++ b/hardware/nic/ixgbe.pan
@@ -1,15 +1,4 @@
-######################################################
-#
-# template hardware/nic/ixgbe;
-#
-# RESPONSIBLE: Victor Mendoza <mendoza@lpnhe.in2p3.fr>
-#
-######################################################
-
 structure template hardware/nic/ixgbe;
 
-"driver" = "ixgbe";
-"pxe"    = false;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Intel 10 GbE PCIe";
+include 'hardware/nic/legacy/ixgbe';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/legacy/3c59x.pan
+++ b/hardware/nic/legacy/3c59x.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/3c59x;
+
+"driver" = "3c59x";
+"pxe"    = false;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "3COM 3c59x";

--- a/hardware/nic/legacy/bcm5700.pan
+++ b/hardware/nic/legacy/bcm5700.pan
@@ -1,0 +1,8 @@
+structure template hardware/nic/legacy/bcm5700;
+
+"driver" = "bcm5700";
+"driverrpms" = list("bcm5700", "bcm5700-smp");
+"pxe"    = true;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Broadcom PCI-X 10/100/1000BASE-T Controller";

--- a/hardware/nic/legacy/be2net.pan
+++ b/hardware/nic/legacy/be2net.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/be2net;
+
+"driver" = "be2net";
+"pxe"    = true;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Emulex OneConnect 10Gb NIC";

--- a/hardware/nic/legacy/bnx2.pan
+++ b/hardware/nic/legacy/bnx2.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/bnx2;
+
+"driver" = "bnx2";
+"pxe"    = true;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Broadcom NetXtreme II";

--- a/hardware/nic/legacy/bnx2x.pan
+++ b/hardware/nic/legacy/bnx2x.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/bnx2x;
+
+"driver" = "bnx2x";
+"pxe"    = true;
+"boot"   = true;
+"media"  = "Ethernet";
+"name"   = "Broadcom NetXtreme II BCM57711 10-Gigabit PCIe";

--- a/hardware/nic/legacy/e100.pan
+++ b/hardware/nic/legacy/e100.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/e100;
+
+"driver" = "intelpro100";
+"pxe"    = false;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Intel 82555 10/100 Megabit card";

--- a/hardware/nic/legacy/e1000.pan
+++ b/hardware/nic/legacy/e1000.pan
@@ -1,0 +1,8 @@
+structure template hardware/nic/legacy/e1000;
+
+"driver" = "e1000";
+"pxe"    = false;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Intel e1000 Gigabit card";
+"maxspeed" = 1000;

--- a/hardware/nic/legacy/e1000e.pan
+++ b/hardware/nic/legacy/e1000e.pan
@@ -1,0 +1,8 @@
+structure template hardware/nic/legacy/e1000e;
+
+"driver" = "e1000e";
+"pxe"    = false;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Intel e1000 Gigabit card";
+"maxspeed" = 1000;

--- a/hardware/nic/legacy/igb.pan
+++ b/hardware/nic/legacy/igb.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/igb;
+
+"driver" = "igb";
+"pxe"    = false;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Intel 82575/6 and 82580-Based Gigabit Network";

--- a/hardware/nic/legacy/ixgbe.pan
+++ b/hardware/nic/legacy/ixgbe.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/ixgbe;
+
+"driver" = "ixgbe";
+"pxe"    = false;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Intel 10 GbE PCIe";

--- a/hardware/nic/legacy/mcp55.pan
+++ b/hardware/nic/legacy/mcp55.pan
@@ -1,0 +1,8 @@
+structure template hardware/nic/legacy/mcp55;
+
+"driver" = "forcedeth";
+"pxe"    = true;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "nVidia nForce MCP55 Gigabit card";
+"maxspeed" = 1000;

--- a/hardware/nic/legacy/myri10ge.pan
+++ b/hardware/nic/legacy/myri10ge.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/myri10ge;
+
+"driver" = "myri10ge";
+"pxe"    = false;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Intel 10 GbE PCIe";

--- a/hardware/nic/legacy/neterion.pan
+++ b/hardware/nic/legacy/neterion.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/neterion;
+
+"driver" = "s2io";
+"pxe"    = false;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Neterion XFrame 10Gb card";

--- a/hardware/nic/legacy/netxen.pan
+++ b/hardware/nic/legacy/netxen.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/netxen;
+
+"driver" = "netxen_nic";
+"pxe"    = true;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "NetXen 1/10 GbE";

--- a/hardware/nic/legacy/pcnet32.pan
+++ b/hardware/nic/legacy/pcnet32.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/pcnet32;
+
+"driver" = "pcnet32";
+"pxe"    = true;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "AMD PCNet 32";

--- a/hardware/nic/legacy/qlge.pan
+++ b/hardware/nic/legacy/qlge.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/qlge;
+
+"driver" = "qlge";
+"pxe"    = true;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Qlogic 10Gb CNA";

--- a/hardware/nic/legacy/tg3.pan
+++ b/hardware/nic/legacy/tg3.pan
@@ -1,0 +1,8 @@
+structure template hardware/nic/legacy/tg3;
+
+"driver" = "tg3";
+"pxe"    = true;
+"boot"   = false;
+"media"  = "Ethernet";
+"name"   = "Broadcom Gigabit chip set";
+"maxspeed" = 1000;

--- a/hardware/nic/legacy/xen_vif.pan
+++ b/hardware/nic/legacy/xen_vif.pan
@@ -1,0 +1,7 @@
+structure template hardware/nic/legacy/xen_vif;
+
+"driver" = "xen";
+"pxe"    = true;
+"boot"   = true;
+"media"  = "Ethernet";
+"name"   = "Xen Virtual NIC";

--- a/hardware/nic/mcp55.pan
+++ b/hardware/nic/mcp55.pan
@@ -1,8 +1,4 @@
 structure template hardware/nic/mcp55;
 
-"driver" = "forcedeth";
-"pxe"    = true;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "nVidia nForce MCP55 Gigabit card";
-"maxspeed" = 1000;
+include 'hardware/nic/legacy/mcp55';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/mellanox/mt26418.pan
+++ b/hardware/nic/mellanox/mt26418.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/mellanox/mt26418;
+
+'model' = 'mt26418';
+'manufacturer' = 'mellanox';
+'driver' = 'mlx4_en';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Mellanox Technologies MT26418 [ConnectX VPI PCIe 2.0 5GT/s - IB DDR / 10GigE]';
+'maxspeed' = 10000;

--- a/hardware/nic/mellanox/mt27500.pan
+++ b/hardware/nic/mellanox/mt27500.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/mellanox/mt27500;
+
+'model' = 'mt27500';
+'manufacturer' = 'mellanox';
+'driver' = 'mlx4_en';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Mellanox Technologies MT27500 Family [ConnectX-3]';
+'maxspeed' = 10000;

--- a/hardware/nic/mellanox/mt27520.pan
+++ b/hardware/nic/mellanox/mt27520.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/mellanox/mt27520;
+
+'model' = 'mt27520';
+'manufacturer' = 'mellanox';
+'driver' = 'mlx4_en';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Mellanox Technologies MT27520 Family [ConnectX-3 Pro]';
+'maxspeed' = 10000;

--- a/hardware/nic/myri10ge.pan
+++ b/hardware/nic/myri10ge.pan
@@ -1,14 +1,4 @@
-######################################################
-#
-# template hardware/nic/myri10ge;
-#
-# RESPONSIBLE: Liliana Martin
-######################################################
-
 structure template hardware/nic/myri10ge;
 
-"driver" = "myri10ge";
-"pxe"    = false;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Intel 10 GbE PCIe";
+include 'hardware/nic/legacy/myri10ge';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/neterion.pan
+++ b/hardware/nic/neterion.pan
@@ -1,15 +1,4 @@
-######################################################
-#
-# from template pro_hardware_card_nic_e1000;
-#
-# RESPONSIBLE: Charles Loomis <charles.loomis@cern.ch>
-#
-######################################################
-
 structure template hardware/nic/neterion;
 
-"driver" = "s2io";
-"pxe"    = false;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Neterion XFrame 10Gb card";
+include 'hardware/nic/legacy/neterion';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/netxen.pan
+++ b/hardware/nic/netxen.pan
@@ -1,13 +1,4 @@
-######################################################
-#
-# template hardware/nic/netxen;
-#
-######################################################
-
 structure template hardware/nic/netxen;
 
-"driver" = "netxen_nic";
-"pxe"    = true;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "NetXen 1/10 GbE";
+include 'hardware/nic/legacy/netxen';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/nvidia/mcp55.pan
+++ b/hardware/nic/nvidia/mcp55.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/nvidia/mcp55;
+
+'model' = 'mcp55';
+'manufacturer' = 'nvidia';
+'driver' = 'forcedeth';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'nVidia nForce MCP55 Gigabit card';
+'maxspeed' = 1000;

--- a/hardware/nic/pcnet32.pan
+++ b/hardware/nic/pcnet32.pan
@@ -1,15 +1,4 @@
-######################################################
-#
-# template pro_hardware_card_nic_pcnet32;
-#
-# RESPONSIBLE: Charles Loomis <charles.loomis@cern.ch>
-#
-######################################################
-
 structure template hardware/nic/pcnet32;
 
-"driver" = "pcnet32";
-"pxe"    = true;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "AMD PCNet 32";
+include 'hardware/nic/legacy/pcnet32';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/qlge.pan
+++ b/hardware/nic/qlge.pan
@@ -1,15 +1,4 @@
-######################################################
-#
-# template hardware/nic/qlge;
-#
-# RESPONSIBLE: Victor Mendoza <mendoza@lpnhe.in2p3.fr>
-#
-######################################################
-
 structure template hardware/nic/qlge;
 
-"driver" = "qlge";
-"pxe"    = true;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Qlogic 10Gb CNA";
+include 'hardware/nic/legacy/qlge';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/tg3.pan
+++ b/hardware/nic/tg3.pan
@@ -1,16 +1,4 @@
-######################################################
-#
-# template pro_hardware_card_nic_tg3;
-#
-# RESPONSIBLE: Charles Loomis <charles.loomis@cern.ch>
-#
-######################################################
-
 structure template hardware/nic/tg3;
 
-"driver" = "tg3";
-"pxe"    = true;
-"boot"   = false;
-"media"  = "Ethernet";
-"name"   = "Broadcom Gigabit chip set";
-"maxspeed" = 1000;
+include 'hardware/nic/legacy/tg3';
+include 'hardware/nic/deprecation-warning';

--- a/hardware/nic/xen_vif.pan
+++ b/hardware/nic/xen_vif.pan
@@ -1,15 +1,4 @@
-######################################################
-#
-# template hardware/nic/xen_vif
-#
-# RESPONSIBLE: Stephen Childs <childss@cs.tcd.ie>
-#
-######################################################
-
 structure template hardware/nic/xen_vif;
 
-"driver" = "xen";
-"pxe"    = true;
-"boot"   = true;
-"media"  = "Ethernet";
-"name"   = "Xen Virtual NIC";
+include 'hardware/nic/legacy/xen_vif';
+include 'hardware/nic/deprecation-warning';


### PR DESCRIPTION
This change adds a directory under `hardware/nic/` for each nic manufacturer, much like the structure of the `hardware/cpu/` tree. This change is a requirement for sites that use aquilon, as aquilon requires models of machine, nic and cpu etc. to be grouped together by manufacturer (or vendor). It is also necessary as at RAL we have recently needed to apply differing, special configuration to different models of nic that use the same driver. This was made difficult with some templates having the name of the `model` and others having the name of the `driver`. 

- All templates under `hardware/nic/$nic_manufacturer/` have values for the `model`, `manufacturer`, `driver`, `pxe`, `boot`, `media`, `name` and `maxspeed` defined. The value of `name` is taken from the first line in the text returned for the nic after running `lspci`.

- The name of each template is equal to the value of `model`. Templates are located under `hardware/nic/` in a directory of the same name as the value of `manufacturer`.

- The original templates have been moved to the directory `hardware/nic/legacy/`. They have had their comment headers removed and their template declarations updated, but are otherwise unmodified.

- The contents of the original templates immediately under `hardware/nic/` have been replaced by an include statement to the template now under `hardware/nic/legacy/` and an include statement to a deprecation warning.

- Most of the model-named, legacy templates have a new-format template that is equivalent: e.g.
```
hardware/nic/legacy/bcm5700 => hardware/nic/broadcom/bcm5700
```
- Driver-named, legacy templates may have an equivalent model-named, new-format template available: e.g.
```
hardware/nic/legacy/ixgbe => hardware/nic/intel/x520
```
- However, some model-named, legacy templates do not have an equivalent new-format template available. This is because their legacy template does not contain the full set of values for the keys listed in the first bullet point above and I neither have an example of the model available nor can I find sufficient information online to complete the full set of values. Of all the model-named, legacy templates the only template I can't find an equivalent for is: `neterion`.

- I'm sure that sites can contribute what they need, if it is not already present, if we leave enough time between this change and the removal of the legacy templates.