### PR TITLE
filesystem/config: add support for configuring a biosboot partition (legacy BIOS or UEFI)

### DIFF
--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -3,7 +3,7 @@
 
 unique template filesystem/config;
 
-include { 'quattor/functions/filesystem' };
+include 'quattor/functions/filesystem';
 
 
 @{
@@ -293,7 +293,7 @@ variable DISK_DEVICE_LIST ?= list('boot',
 
 
 # Include site-specific customization to volume list or creation order
-include { FILESYSTEM_LAYOUT_CONFIG_SITE };
+include FILESYSTEM_LAYOUT_CONFIG_SITE;
 
 # Define some defaults if not yet defined
 variable FILESYSTEM_DEFAULT_FS_TYPE ?= 'ext3';
@@ -919,13 +919,9 @@ variable DISK_LV_BY_VG = {
 };
 
 # Set requested permissions or owner (if any) on filesystem mountpoints
-include {
-	if (exists(DUMMY_NODE) && DUMMY_NODE) {
-		return(null);
-	} else {
-		return('components/dirperm/config');
-	};
-};
+# FIXME: DUMMY_NODE is not really supported anymore (was useful mainly at the time
+# of SPMA) and this should probably be removed.
+include if ( !exists(DUMMY_NODE) || !DUMMY_NODE) 'components/dirperm/config';
 '/software/components/dirperm' = {
   if ( !exists(SELF['paths']) || !is_defined(SELF['paths']) ) {
     SELF['paths'] = list();

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -206,6 +206,14 @@ required = no
 }
 variable DISK_VG01_BLOCKDEV_SIZE ?= -1;
 
+@{
+desc =  default name for default volume group
+values = string
+default = vg.01
+required = no
+}
+variable DISK_VG01_VOLGROUP_NAME ?= 'vg.01';
+
 
 # Define list of volume (partition, logical volumes, md...).
 # Default list is a disk with 4 partitions : /boot, /, swap and one partition for LVM.
@@ -227,12 +235,12 @@ variable DISK_VOLUME_PARAMS ?= {
   SELF['home'] = nlist('size', DISK_HOME_BLOCKDEV_SIZE,
                        'mountpoint', '/home',
                        'type', 'lvm',
-                       'volgroup', 'vg.01',
+                       'volgroup', DISK_VG01_VOLGROUP_NAME,
                        'device', 'homevol');
   SELF['opt'] = nlist('size', DISK_OPT_BLOCKDEV_SIZE,
                       'mountpoint', '/opt',
                       'type', 'lvm',
-                      'volgroup', 'vg.01',
+                      'volgroup', DISK_VG01_VOLGROUP_NAME,
                       'device', 'optvol');
   SELF['root'] = nlist('size', DISK_ROOT_BLOCKDEV_SIZE,
                        'mountpoint', '/',
@@ -246,26 +254,26 @@ variable DISK_VOLUME_PARAMS ?= {
   SELF['swareas'] = nlist('size', DISK_SWAREAS_BLOCKDEV_SIZE,
                           'mountpoint', '/swareas',
                           'type', 'lvm',
-                          'volgroup', 'vg.01',
+                          'volgroup', DISK_VG01_VOLGROUP_NAME,
                           'device', 'swareasvol');
   SELF['tmp'] = nlist('size', DISK_TMP_BLOCKDEV_SIZE,
                       'mountpoint', '/tmp',
                       'type', 'lvm',
-                      'volgroup', 'vg.01',
+                      'volgroup', DISK_VG01_VOLGROUP_NAME,
                       'device', 'tmpvol');
   SELF['usr'] = nlist('size', DISK_USR_BLOCKDEV_SIZE,
                       'mountpoint', '/usr',
                       'type', 'lvm',
-                      'volgroup', 'vg.01',
+                      'volgroup', DISK_VG01_VOLGROUP_NAME,
                       'device', 'usrvol');
   SELF['var'] = nlist('size', DISK_VAR_BLOCKDEV_SIZE,
                       'mountpoint', '/var',
                       'type', 'lvm',
-                      'volgroup', 'vg.01',
+                      'volgroup', DISK_VG01_VOLGROUP_NAME,
                       'device', 'varvol');
-  SELF['vg.01'] = nlist('size', DISK_VG01_BLOCKDEV_SIZE,
-                        'type', 'vg',
-                        'devices', list(DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('lvm',DISK_BOOT_PARTS)+1)));
+  SELF[DISK_VG01_VOLGROUP_NAME] = nlist('size', DISK_VG01_BLOCKDEV_SIZE,
+                                        'type', 'vg',
+                                        'devices', list(DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('lvm',DISK_BOOT_PARTS)+1)));
   SELF;
 };
 

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -65,13 +65,8 @@ variable DISK_BOOT_PART_PREFIX ?= if ( exists('/hardware/harddisks/'+DISK_BOOT_D
 # Add the required biosboot partition if the disk is using a GPT label, BIOS is using legacy mode
 # Define biosboot partition size accordingly
 variable DISK_BOOT_ADD_BIOSBOOT_PART ?= false;
-variable DISK_BOOT_BIOSBOOT_PART_SIZE ?= if ( DISK_BOOT_ADD_BIOSBOOT_PART ) {
-                                           100*MB;
-                                         } else {
-                                           0;
-                                         };
-                                         
-#
+
+
 # An ordered list of partition. Index will be used to build device name (index+1).
 # Values must match key in DISK_VOLUME_PARAMS.
 variable DISK_BOOT_PARTS = list(
@@ -101,6 +96,82 @@ variable DISK_SWAP_SIZE ?= {
   swap_size;
 };
 
+@{
+desc =  default size for block device biosboot
+values = long
+default = 100 MB if using GPT label, 0 otherwise
+required = no
+}
+variable DISK_BIOSBOOT_BLOCKDEV_SIZE ?= if ( DISK_BOOT_ADD_BIOSBOOT_PART ) {
+                                          100*MB;
+                                        } else {
+                                          0;
+                                        };
+                                         
+@{
+desc =  default size for block device boot
+values = long
+default = 256 MB
+required = no
+}
+variable DISK_BOOT_BLOCKDEV_SIZE ?= 256*MB;
+@{
+desc =  default size for block device home
+values = long
+default = 0 (not created)
+required = no
+}
+variable DISK_HOME_BLOCKDEV_SIZE ?= 0*GB;
+@{
+desc =  default size for block device opt
+values = long
+default = 2 GB
+required = no
+}
+variable DISK_OPT_BLOCKDEV_SIZE ?= 2*GB;
+@{
+desc =  default size for block device root
+values = long
+default = 1 GB
+required = no
+}
+variable DISK_ROOT_BLOCKDEV_SIZE ?= 1*GB;
+@{
+desc =  default size for block device swareas
+values = long
+default = 0 (not created)
+required = no
+}
+variable DISK_SWAREAS_BLOCKDEV_SIZE ?= 0*GB;
+@{
+desc =  default size for block device tmp
+values = long
+default = 1 GB
+required = no
+}
+variable DISK_TMP_BLOCKDEV_SIZE ?= 1*GB;
+@{
+desc =  default size for block device usr
+values = long
+default = 5 GB
+required = no
+}
+variable DISK_USR_BLOCKDEV_SIZE ?= 5*GB;
+@{
+desc =  default size for block device var
+values = long
+default = -1 (remaining unused space)
+required = no
+}
+variable DISK_VAR_BLOCKDEV_SIZE ?= -1;
+@{
+desc =  default size for block device vg.01
+values = long
+default = -1 (remaining unused space)
+required = no
+}
+variable DISK_VG01_BLOCKDEV_SIZE ?= -1;
+
 
 # Define list of volume (partition, logical volumes, md...).
 # Default list is a disk with 4 partitions : /boot, /, swap and one partition for LVM.
@@ -110,26 +181,26 @@ variable DISK_SWAP_SIZE ?= {
 # designated by FILESYSTEM_LAYOUT_CONFIG_SITE (this variable is defined when this template is executed).
 # Key is an arbitrary name referenced by DISK_DEVICE_LIST.
 variable DISK_VOLUME_PARAMS ?= {
-  SELF['biosboot'] = nlist('size', DISK_BOOT_BIOSBOOT_PART_SIZE,
+  SELF['biosboot'] = nlist('size', DISK_BIOSBOOT_BLOCKDEV_SIZE,
                        'type', 'partition',
                        'flags', list('bios_grub'),
                        'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('boot',DISK_BOOT_PARTS)+1));
-  SELF['boot'] = nlist('size', 256*MB,
+  SELF['boot'] = nlist('size', DISK_BOOT_BLOCKDEV_SIZE,
                        'mountpoint', '/boot',
                        'fstype', 'ext2',
                        'type', 'partition',
                        'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('boot',DISK_BOOT_PARTS)+1));
-  SELF['home'] = nlist('size', 0*GB,
+  SELF['home'] = nlist('size', DISK_HOME_BLOCKDEV_SIZE,
                        'mountpoint', '/home',
                        'type', 'lvm',
                        'volgroup', 'vg.01',
                        'device', 'homevol');
-  SELF['opt'] = nlist('size', 2*GB,
+  SELF['opt'] = nlist('size', DISK_OPT_BLOCKDEV_SIZE,
                       'mountpoint', '/opt',
                       'type', 'lvm',
                       'volgroup', 'vg.01',
                       'device', 'optvol');
-  SELF['root'] = nlist('size', 1*GB,
+  SELF['root'] = nlist('size', DISK_ROOT_BLOCKDEV_SIZE,
                        'mountpoint', '/',
                        'type', 'partition',
                        'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('root',DISK_BOOT_PARTS)+1));
@@ -138,27 +209,27 @@ variable DISK_VOLUME_PARAMS ?= {
                        'fstype', 'swap',
                        'type', 'partition',
                        'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('swap',DISK_BOOT_PARTS)+1));
-  SELF['swareas'] = nlist('size', 0*GB,
+  SELF['swareas'] = nlist('size', DISK_SWAREAS_BLOCKDEV_SIZE,
                           'mountpoint', '/swareas',
                           'type', 'lvm',
                           'volgroup', 'vg.01',
                           'device', 'swareasvol');
-  SELF['tmp'] = nlist('size', 1*GB,
+  SELF['tmp'] = nlist('size', DISK_TMP_BLOCKDEV_SIZE,
                       'mountpoint', '/tmp',
                       'type', 'lvm',
                       'volgroup', 'vg.01',
                       'device', 'tmpvol');
-  SELF['usr'] = nlist('size', 5*GB,
+  SELF['usr'] = nlist('size', DISK_USR_BLOCKDEV_SIZE,
                       'mountpoint', '/usr',
                       'type', 'lvm',
                       'volgroup', 'vg.01',
                       'device', 'usrvol');
-  SELF['var'] = nlist('size', -1,
+  SELF['var'] = nlist('size', DISK_VAR_BLOCKDEV_SIZE,
                       'mountpoint', '/var',
                       'type', 'lvm',
                       'volgroup', 'vg.01',
                       'device', 'varvol');
-  SELF['vg.01'] = nlist('size', -1,
+  SELF['vg.01'] = nlist('size', DISK_VG01_BLOCKDEV_SIZE,
                         'type', 'vg',
                         'devices', list(DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('lvm',DISK_BOOT_PARTS)+1)));
   SELF;

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -214,6 +214,14 @@ required = no
 }
 variable DISK_VG01_VOLGROUP_NAME ?= 'vg.01';
 
+@{
+desc =  partition flags for biosboot partition
+values = list of strings (matching valid partition flag names in blockdevices schema)
+default = bios_grub
+required = no
+}
+variable DISK_BIOSBOOT_PART_FLAGS ?= list('bios_grub');
+
 
 # Define list of volume (partition, logical volumes, md...).
 # Default list is a disk with 4 partitions : /boot, /, swap and one partition for LVM.
@@ -225,7 +233,7 @@ variable DISK_VG01_VOLGROUP_NAME ?= 'vg.01';
 variable DISK_VOLUME_PARAMS ?= {
   SELF['biosboot'] = nlist('size', DISK_BIOSBOOT_BLOCKDEV_SIZE,
                        'type', 'partition',
-                       'flags', list('bios_grub'),
+                       'flags', DISK_BIOSBOOT_PART_FLAGS,
                        'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('biosboot',DISK_BOOT_PARTS)+1));
   SELF['boot'] = nlist('size', DISK_BOOT_BLOCKDEV_SIZE,
                        'mountpoint', '/boot',

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -141,6 +141,7 @@ default = 256 MB
 required = no
 }
 variable DISK_BOOT_BLOCKDEV_SIZE ?= 256*MB;
+
 @{
 desc =  default size for block device home
 values = long
@@ -148,6 +149,7 @@ default = 0 (not created)
 required = no
 }
 variable DISK_HOME_BLOCKDEV_SIZE ?= 0*GB;
+
 @{
 desc =  default size for block device opt
 values = long
@@ -155,6 +157,7 @@ default = 2 GB
 required = no
 }
 variable DISK_OPT_BLOCKDEV_SIZE ?= 2*GB;
+
 @{
 desc =  default size for block device root
 values = long
@@ -162,6 +165,7 @@ default = 1 GB
 required = no
 }
 variable DISK_ROOT_BLOCKDEV_SIZE ?= 1*GB;
+
 @{
 desc =  default size for block device swareas
 values = long
@@ -169,6 +173,7 @@ default = 0 (not created)
 required = no
 }
 variable DISK_SWAREAS_BLOCKDEV_SIZE ?= 0*GB;
+
 @{
 desc =  default size for block device tmp
 values = long
@@ -176,6 +181,7 @@ default = 1 GB
 required = no
 }
 variable DISK_TMP_BLOCKDEV_SIZE ?= 1*GB;
+
 @{
 desc =  default size for block device usr
 values = long
@@ -183,6 +189,7 @@ default = 5 GB
 required = no
 }
 variable DISK_USR_BLOCKDEV_SIZE ?= 5*GB;
+
 @{
 desc =  default size for block device var
 values = long
@@ -190,6 +197,7 @@ default = -1 (remaining unused space)
 required = no
 }
 variable DISK_VAR_BLOCKDEV_SIZE ?= -1;
+
 @{
 desc =  default size for block device vg.01
 values = long

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -210,7 +210,7 @@ variable DISK_VOLUME_PARAMS ?= {
   SELF['biosboot'] = nlist('size', DISK_BIOSBOOT_BLOCKDEV_SIZE,
                        'type', 'partition',
                        'flags', list('bios_grub'),
-                       'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('boot',DISK_BOOT_PARTS)+1));
+                       'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('biosboot',DISK_BOOT_PARTS)+1));
   SELF['boot'] = nlist('size', DISK_BOOT_BLOCKDEV_SIZE,
                        'mountpoint', '/boot',
                        'fstype', 'ext2',

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -5,7 +5,27 @@ unique template filesystem/config;
 
 include { 'quattor/functions/filesystem' };
 
+
+@{
+desc =  template customizing the default disk layout provided by the default configuration
+values = template namespace
+default = null
+required = no
+}
 variable FILESYSTEM_LAYOUT_CONFIG_SITE ?= null;
+
+@{
+desc =  template included at the beginning of the file system configuration and allowing to \
+ to redefine the default size of block devices defined in the default configuration
+values = template namespace
+default = FILESYSTEM_LAYOUT_CONFIG_SITE+'-init' or null if FILESYSTEM_LAYOUT_CONFIG_SITE is undefined
+required = no
+}
+variable FILESYSTEM_LAYOUT_CONFIG_INIT ?= if ( is_defined(FILESYSTEM_LAYOUT_CONFIG_SITE) ) {
+                                            if_exists(FILESYSTEM_LAYOUT_CONFIG_SITE + '-init');
+                                          } else {
+                                            null;
+                                          };
 
 # The following variables define defaults for file systems and partitions.
 # They are actually defined after including FILESYSTEM_LAYOUT_CONFIG_SITE.
@@ -37,6 +57,12 @@ function filesystem_layout_mod = {
   SELF;
 };
 
+
+# Include site configuration initialization if any
+include FILESYSTEM_LAYOUT_CONFIG_INIT;
+
+
+# Retrieve boot device name based on HW configuration
 variable DISK_BOOT_DEV ?= boot_disk();
 variable DISK_BOOT_DEV ?= {
   if (exists("/hardware/harddisks/sda")) {

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -596,7 +596,7 @@ variable DISK_PART_BY_DEV = {
       } else {
         partition = phys_dev + SELF['partitions'][phys_dev]['part_prefix'] + to_string(last_primary+1);
         debug('Creating '+partition+' as an extended partition using unused part of '+phys_dev);
-        new_part_list[partition] = -1;
+        new_part_list[partition]['size'] = -1;
         last_primary = last_primary + 1;
         SELF['partitions'][phys_dev]['extended'] = last_primary;
       };
@@ -638,7 +638,7 @@ variable DISK_PART_BY_DEV = {
 
         new_part_name = phys_dev + SELF['partitions'][phys_dev]['part_prefix'] + to_string(no_size_part_num);
         debug('Assigning partition name '+new_part_name+' to former '+old_part_name+' (no explicit size)');
-        new_part_list[new_part_name] = -1;
+        new_part_list[new_part_name]['size'] = -1;
         if ( old_part_name != new_part_name ) {
           SELF['changed_part_num'][old_part_name] = new_part_name;
         };

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -37,12 +37,12 @@ variable FILESYSTEM_LAYOUT_CONFIG_INIT ?= if ( is_defined(FILESYSTEM_LAYOUT_CONF
 # Function to update DISK_VOLUME_PARAMS.
 # This function allows to merge site-specific volume parameters with default ones.
 # Calling sequence is  :
-#    variable DISK_VOLUME_PARAMS = filesystem_layout_mod(volume_nlist);
-# where 'volume_nlist' has the same format as DISK_VOLUME_PARAMS.
+#    variable DISK_VOLUME_PARAMS = filesystem_layout_mod(volume_dict);
+# where 'volume_dict' has the same format as DISK_VOLUME_PARAMS.
 function filesystem_layout_mod = {
   function_name = 'filesystem_layout_mod';
-  if ( (ARGC != 1) || !is_nlist(ARGV[0]) ) {
-    error(function_name+': one argument required, must be a nlist');
+  if ( (ARGC != 1) || !is_dict(ARGV[0]) ) {
+    error(function_name+': one argument required, must be a dict');
   };
 
   foreach (volume;params;ARGV[0]) {
@@ -231,57 +231,57 @@ variable DISK_BIOSBOOT_PART_FLAGS ?= list('bios_grub');
 # designated by FILESYSTEM_LAYOUT_CONFIG_SITE (this variable is defined when this template is executed).
 # Key is an arbitrary name referenced by DISK_DEVICE_LIST.
 variable DISK_VOLUME_PARAMS ?= {
-  SELF['biosboot'] = nlist('size', DISK_BIOSBOOT_BLOCKDEV_SIZE,
-                       'type', 'partition',
-                       'flags', DISK_BIOSBOOT_PART_FLAGS,
-                       'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('biosboot',DISK_BOOT_PARTS)+1));
-  SELF['boot'] = nlist('size', DISK_BOOT_BLOCKDEV_SIZE,
-                       'mountpoint', '/boot',
-                       'fstype', 'ext2',
-                       'type', 'partition',
-                       'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('boot',DISK_BOOT_PARTS)+1));
-  SELF['home'] = nlist('size', DISK_HOME_BLOCKDEV_SIZE,
-                       'mountpoint', '/home',
-                       'type', 'lvm',
-                       'volgroup', DISK_VG01_VOLGROUP_NAME,
-                       'device', 'homevol');
-  SELF['opt'] = nlist('size', DISK_OPT_BLOCKDEV_SIZE,
-                      'mountpoint', '/opt',
+  SELF['biosboot'] = dict('size', DISK_BIOSBOOT_BLOCKDEV_SIZE,
+                          'type', 'partition',
+                          'flags', DISK_BIOSBOOT_PART_FLAGS,
+                          'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('biosboot',DISK_BOOT_PARTS)+1));
+  SELF['boot'] = dict('size', DISK_BOOT_BLOCKDEV_SIZE,
+                      'mountpoint', '/boot',
+                      'fstype', 'ext2',
+                      'type', 'partition',
+                      'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('boot',DISK_BOOT_PARTS)+1));
+  SELF['home'] = dict('size', DISK_HOME_BLOCKDEV_SIZE,
+                      'mountpoint', '/home',
                       'type', 'lvm',
                       'volgroup', DISK_VG01_VOLGROUP_NAME,
-                      'device', 'optvol');
-  SELF['root'] = nlist('size', DISK_ROOT_BLOCKDEV_SIZE,
-                       'mountpoint', '/',
-                       'type', 'partition',
-                       'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('root',DISK_BOOT_PARTS)+1));
-  SELF['swap'] = nlist('size', DISK_SWAP_SIZE,
-                       'mountpoint', 'swap',
-                       'fstype', 'swap',
-                       'type', 'partition',
-                       'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('swap',DISK_BOOT_PARTS)+1));
-  SELF['swareas'] = nlist('size', DISK_SWAREAS_BLOCKDEV_SIZE,
-                          'mountpoint', '/swareas',
-                          'type', 'lvm',
-                          'volgroup', DISK_VG01_VOLGROUP_NAME,
-                          'device', 'swareasvol');
-  SELF['tmp'] = nlist('size', DISK_TMP_BLOCKDEV_SIZE,
-                      'mountpoint', '/tmp',
-                      'type', 'lvm',
-                      'volgroup', DISK_VG01_VOLGROUP_NAME,
-                      'device', 'tmpvol');
-  SELF['usr'] = nlist('size', DISK_USR_BLOCKDEV_SIZE,
-                      'mountpoint', '/usr',
-                      'type', 'lvm',
-                      'volgroup', DISK_VG01_VOLGROUP_NAME,
-                      'device', 'usrvol');
-  SELF['var'] = nlist('size', DISK_VAR_BLOCKDEV_SIZE,
-                      'mountpoint', '/var',
-                      'type', 'lvm',
-                      'volgroup', DISK_VG01_VOLGROUP_NAME,
-                      'device', 'varvol');
-  SELF[DISK_VG01_VOLGROUP_NAME] = nlist('size', DISK_VG01_BLOCKDEV_SIZE,
-                                        'type', 'vg',
-                                        'devices', list(DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('lvm',DISK_BOOT_PARTS)+1)));
+                      'device', 'homevol');
+  SELF['opt'] = dict('size', DISK_OPT_BLOCKDEV_SIZE,
+                     'mountpoint', '/opt',
+                     'type', 'lvm',
+                     'volgroup', DISK_VG01_VOLGROUP_NAME,
+                     'device', 'optvol');
+  SELF['root'] = dict('size', DISK_ROOT_BLOCKDEV_SIZE,
+                      'mountpoint', '/',
+                      'type', 'partition',
+                      'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('root',DISK_BOOT_PARTS)+1));
+  SELF['swap'] = dict('size', DISK_SWAP_SIZE,
+                      'mountpoint', 'swap',
+                      'fstype', 'swap',
+                      'type', 'partition',
+                      'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('swap',DISK_BOOT_PARTS)+1));
+  SELF['swareas'] = dict('size', DISK_SWAREAS_BLOCKDEV_SIZE,
+                         'mountpoint', '/swareas',
+                         'type', 'lvm',
+                         'volgroup', DISK_VG01_VOLGROUP_NAME,
+                         'device', 'swareasvol');
+  SELF['tmp'] = dict('size', DISK_TMP_BLOCKDEV_SIZE,
+                     'mountpoint', '/tmp',
+                     'type', 'lvm',
+                     'volgroup', DISK_VG01_VOLGROUP_NAME,
+                     'device', 'tmpvol');
+  SELF['usr'] = dict('size', DISK_USR_BLOCKDEV_SIZE,
+                     'mountpoint', '/usr',
+                     'type', 'lvm',
+                     'volgroup', DISK_VG01_VOLGROUP_NAME,
+                     'device', 'usrvol');
+  SELF['var'] = dict('size', DISK_VAR_BLOCKDEV_SIZE,
+                     'mountpoint', '/var',
+                     'type', 'lvm',
+                     'volgroup', DISK_VG01_VOLGROUP_NAME,
+                     'device', 'varvol');
+  SELF[DISK_VG01_VOLGROUP_NAME] = dict('size', DISK_VG01_BLOCKDEV_SIZE,
+                                       'type', 'vg',
+                                       'devices', list(DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('lvm',DISK_BOOT_PARTS)+1)));
   SELF;
 };
 
@@ -329,7 +329,7 @@ variable PHYSICAL_DEVICE_LABEL ?= null;
 # specific entries defined for the partitions used. In this case, add an entry for the underlying
 # partitions with the appropriate size defined.
 variable DISK_VOLUME_PARAMS = {
-  volumes = nlist();
+  volumes = dict();
   debug('Initial list of file systems: '+to_string(SELF));
 
   # MD-related checks
@@ -342,9 +342,9 @@ variable DISK_VOLUME_PARAMS = {
           # raid1 is used and size is defined for the MD device.
           foreach (i;device;params['devices']) {
             if ( !is_defined(SELF[device]) && exists(params['raid_level']) && (params['raid_level'] == 1) ) {
-              volumes[device] = nlist('device', device,
-                                      'type', 'partition',
-                                      'size', params['size']);
+              volumes[device] = dict('device', device,
+                                     'type', 'partition',
+                                     'size', params['size']);
               debug('Entry added for partition '+device+' used by '+volume+' (size='+to_string(params['size'])+'MB)');
             };
           };
@@ -438,8 +438,8 @@ variable DISK_DEVICE_LIST = {
 #   - 'changed_part_num': an entry for each partition renumbered to use a consecutive numbering. The
 #                         keys are the original partition name, the value the new one.
 variable DISK_PART_BY_DEV = {
-  SELF['partitions'] = nlist();
-  SELF['changed_part_num'] = nlist();
+  SELF['partitions'] = dict();
+  SELF['changed_part_num'] = dict();
   foreach (i;dev_name;DISK_DEVICE_LIST) {
     if ( match(DISK_VOLUME_PARAMS[dev_name]['type'], 'md|vg') ) {
       if ( exists(DISK_VOLUME_PARAMS[dev_name]['devices']) ) {
@@ -458,9 +458,9 @@ variable DISK_PART_BY_DEV = {
         params = DISK_VOLUME_PARAMS[device];
       } else {
         debug('Adding an entry to DISK_PART_BY_DEV for partition '+device+' used by '+dev_name);
-        params = nlist('device', device,
-                       'type', 'partition',
-                       'size', -1);
+        params = dict('device', device,
+                      'type', 'partition',
+                      'size', -1);
       };
       if ( params['type'] == 'partition' ) {
         if ( !exists(params['device'])  ) {
@@ -475,16 +475,16 @@ variable DISK_PART_BY_DEV = {
           phys_dev = toks[1];
         };
         if ( !exists(SELF['partitions'][phys_dev]) ) {
-          # Build 2 separate nlist, part_list and part_num, the key being the partition name in each
+          # Build 2 separate dict, part_list and part_num, the key being the partition name in each
           # list. part_list will be passed to partitions_add() which requires a dict of
           # partitions where the key is a partitionname and the value the partition parameters (as a dict).
           # part_num is a transient dict used internally to do the partition final numbering.
-          SELF['partitions'][phys_dev] = nlist('part_list', nlist(),
-                                               'part_num', nlist(),
-                                               'part_prefix', disk_part_prefix,
-                                               'extended', undef,
-                                               'last_primary', 0,
-                                              );
+          SELF['partitions'][phys_dev] = dict('part_list', dict(),
+                                              'part_num', dict(),
+                                              'part_prefix', disk_part_prefix,
+                                              'extended', undef,
+                                              'last_primary', 0,
+                                             );
         };
         part_num = to_long(toks[2]);
         if ( is_defined(params['size']) ) {
@@ -519,12 +519,12 @@ variable DISK_PART_BY_DEV = {
   # Another check is for partitions without an explicit size (size=-1). It is checked that there is no more
   # than one per disk and this partition will always be renumber to be the last one created.
   #
-  # Note that this code heavily relies on the fact PAN nlists are run through in the lexical order by foreach
+  # Note that this code heavily relies on the fact PAN dicts are run through in the lexical order by foreach
   # statement in panc v8. Should this change, this code would need to be fixed...
 
   foreach (phys_dev;dev_params;SELF['partitions']) {
     new_part_num = 1;
-    new_part_list = nlist();
+    new_part_list = dict();
     primary_no_size = list();
     logical_no_size = list();
     sorted_partition_list = list();
@@ -702,9 +702,9 @@ variable DISK_VOLUME_PARAMS = {
 "/system/blockdevices/physical_devs" = {
   foreach (phys_dev;params;DISK_PART_BY_DEV['partitions']) {
     if (is_defined(PHYSICAL_DEVICE_LABEL) && exists(PHYSICAL_DEVICE_LABEL[phys_dev])) {
-      SELF[phys_dev] = nlist ("label", PHYSICAL_DEVICE_LABEL[phys_dev]);
+      SELF[phys_dev] = dict ("label", PHYSICAL_DEVICE_LABEL[phys_dev]);
     } else {
-      SELF[phys_dev] = nlist ("label", PHYSICAL_DEVICE_DEFAULT_LABEL);
+      SELF[phys_dev] = dict ("label", PHYSICAL_DEVICE_DEFAULT_LABEL);
     };
   };
   SELF;
@@ -766,20 +766,20 @@ variable DISK_VOLUME_PARAMS = {
       };
       if ( params['type'] == 'md') {
         if ( !exists(SELF['md']) ) {
-          SELF['md'] = nlist();
+          SELF['md'] = dict();
         };
         if ( exists(params['raid_level']) ) {
           raid_level = 'RAID'+to_string(params['raid_level']);
         } else {
           raid_level = 'RAID0';
         };
-        SELF['md'][dev_name] = nlist("device_list", partitions,
+        SELF['md'][dev_name] = dict("device_list", partitions,
                                      "raid_level", raid_level);
       } else if ( params['type'] == 'vg' ) {
          if ( !exists(SELF['volume_groups']) ) {
-          SELF['volume_groups'] = nlist();
+          SELF['volume_groups'] = dict();
         };
-        SELF['volume_groups'][dev_name] = nlist("device_list", partitions);
+        SELF['volume_groups'][dev_name] = dict("device_list", partitions);
       };
     };
   };
@@ -806,7 +806,7 @@ variable DISK_LV_BY_VG = {
         error("No volume group defined for logical volume '"+params['device']+"'");
       };
       if ( !exists(SELF[vg_name]) ) {
-        SELF[vg_name] = nlist();
+        SELF[vg_name] = dict();
       };
       if ( exists(params['size']) ) {
         SELF[vg_name][params['device']] = params['size'];
@@ -838,8 +838,8 @@ variable DISK_LV_BY_VG = {
 # Take care of creating logical volume without a defined size last in the volume group.
 "/system/filesystems" = {
   # Create a list of volume per volume group (other partitions/volumes set in 'OTHERS__').
-  volumes = nlist();
-  lastgroup = nlist();
+  volumes = dict();
+  lastgroup = dict();
   defgroup_name = 'OTHERS__';
   volgroups = list(defgroup_name);     # Use to control creation order
   foreach (i;dev_name;DISK_DEVICE_LIST) {
@@ -905,12 +905,12 @@ variable DISK_LV_BY_VG = {
         } else {
           preserve = FILESYSTEM_DEFAULT_PRESERVE;
         };
-        fs_params = nlist ("block_device", block_device,
-                           "mountpoint", params['mountpoint'],
-                           "format", format,
-                           "mount", true,
-                           "preserve", preserve,
-                           "type", fs_type);
+        fs_params = dict ("block_device", block_device,
+                          "mountpoint", params['mountpoint'],
+                          "format", format,
+                          "mount", true,
+                          "preserve", preserve,
+                          "type", fs_type);
         filesystem_mod(fs_params);
       };
     };
@@ -933,8 +933,8 @@ include {
   foreach (i;dev_name;DISK_DEVICE_LIST) {
     params = DISK_VOLUME_PARAMS[dev_name];
     if ( (exists(params['permissions']) || exists(params['owner'])) && exists(params['mountpoint']) ) {
-      path_params = nlist('path', params['mountpoint'],
-                          'type', 'd');
+      path_params = dict('path', params['mountpoint'],
+                         'type', 'd');
       if ( exists(params['owner']) ) {
         path_params['owner'] = params['owner'];
       } else {

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -919,9 +919,7 @@ variable DISK_LV_BY_VG = {
 };
 
 # Set requested permissions or owner (if any) on filesystem mountpoints
-# FIXME: DUMMY_NODE is not really supported anymore (was useful mainly at the time
-# of SPMA) and this should probably be removed.
-include if ( !exists(DUMMY_NODE) || !DUMMY_NODE) 'components/dirperm/config';
+include 'components/dirperm/config';
 '/software/components/dirperm' = {
   if ( !exists(SELF['paths']) || !is_defined(SELF['paths']) ) {
     SELF['paths'] = list();

--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -831,7 +831,7 @@ variable DISK_PART_BY_DEV = {
 # DISK_VOLUME_PARAMS: this flag explicitly states that this entry correspond to a
 # physical partition description and that no attempt should be made to dereference it.
 variable DISK_VOLUME_PARAMS = {
-  foreach (volume;params;DISK_VOLUME_PARAMS) {
+  foreach (volume;params;SELF) {
     if ( (params['type'] == 'partition') &&
          is_defined(DISK_PART_BY_DEV['changed_part_num'][params['device']]) ) {
       debug(format('%s: updating %s device to new partition name/number: %s', 

--- a/filesystem/config.pan.new
+++ b/filesystem/config.pan.new
@@ -75,7 +75,7 @@ variable DISK_BOOT_BIOSBOOT_PART_SIZE ?= if ( DISK_BOOT_ADD_BIOSBOOT_PART ) {
 # An ordered list of partition. Index will be used to build device name (index+1).
 # Values must match key in DISK_VOLUME_PARAMS.
 variable DISK_BOOT_PARTS = list(
-  'biosboot',
+  if ( DISK_BOOT_GPT_LABEL ) 'biosboot',
   'boot',
   'root',
   'swap',
@@ -112,8 +112,8 @@ variable DISK_SWAP_SIZE ?= {
 variable DISK_VOLUME_PARAMS ?= {
   SELF['biosboot'] = nlist('size', DISK_BOOT_BIOSBOOT_PART_SIZE,
                        'type', 'partition',
-                       'flags', list('bios_grub'),
-                       'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('boot',DISK_BOOT_PARTS)+1));
+                       'device', DISK_BOOT_DEV+DISK_BOOT_PART_PREFIX+to_string(index('boot',DISK_BOOT_PARTS)+1)),
+                       'flags', list('bios_grub');
   SELF['boot'] = nlist('size', 256*MB,
                        'mountpoint', '/boot',
                        'fstype', 'ext2',
@@ -366,16 +366,7 @@ variable DISK_PART_BY_DEV = {
                                               );
         };
         part_num = to_long(toks[2]);
-        if ( is_defined(params['size']) ) {
-          SELF['partitions'][phys_dev]['part_list'][params['device']]['size'] = params['size'];
-        } else {
-          # Assume rest of physical device by default
-          SELF['partitions'][phys_dev]['part_list'][params['device']]['size'] = -1;
-        };
-        # 'flags' is a list of property that will be set to true in the block device configuration
-        if ( is_defined(params['flags']) ) {
-          SELF['partitions'][phys_dev]['part_list'][params['device']]['flags'] = params['flags'];
-        };
+        SELF['partitions'][phys_dev]['part_list'][params['device']] = params['size'];
         SELF['partitions'][phys_dev]['part_num'][params['device']] = part_num;
         if ( is_defined(params['subtype']) && (params['subtype'] == 'extended') ) {
           if ( is_defined(SELF['partitions'][phys_dev]['extended']) ) {
@@ -389,8 +380,6 @@ variable DISK_PART_BY_DEV = {
     };
   };
 
-  debug(format('%s: devices defined before partition renumbering = %s', OBJECT, to_string(SELF['partitions'])));
-  
   # Process SELF['partitions'] and ensure that for each device, partition numbers are consecutive but keeping
   # logical partitions >=5. Renumbering cannot be used only based on the alphabetical order of partitions as
   # there may be 2 digits for the partition number.
@@ -434,6 +423,9 @@ variable DISK_PART_BY_DEV = {
       # Also if the partition as no explicit size (size=-1), add it
       # to the list of primary partitions without and explicit size.
       # An extended partition is treated as a primary one at this point.
+      if ( ! is_defined(SELF['partitions'][phys_dev]['part_list'][partition]['size'] == -1) ) {
+        SELF['partitions'][phys_dev]['part_list'][partition]['size'] = -1;
+      };
       if ( (part_num <= 4)  || (label == "gpt") ) {
         if ( SELF['partitions'][phys_dev]['part_list'][partition]['size'] == -1 ) {
           debug('Primary/extended partition '+partition+' has no size defined. Postponing allocation of a partition number.');
@@ -448,14 +440,14 @@ variable DISK_PART_BY_DEV = {
         if ( new_part_num <= 4 ) {
           new_part_num = 5;
         };
-        if ( SELF['partitions'][phys_dev]['part_list'][partition]['size'] == -1 ) {
+        if ( SELF['partitions'][phys_dev]['size'][partition] == -1 ) {
           debug('Logical partition '+partition+' has no size defined. Postponing allocation of a partition number.');
           logical_no_size[length(logical_no_size)] = part_num;
         };
       };
       # If the partition has no defined size (size=-1), ignore it at the moment.
       # It number will be assigned later.
-      if ( SELF['partitions'][phys_dev]['part_list'][partition]['size'] != -1 ) {
+      if ( SELF['partitions'][phys_dev]['size'][partition] != -1 ) {
         if ( part_num == new_part_num ) {
           new_part_name = partition;
         } else {
@@ -463,7 +455,7 @@ variable DISK_PART_BY_DEV = {
           debug('Renaming partition '+partition+' into '+new_part_name);
           SELF['changed_part_num'][partition] = new_part_name;
         };
-        new_part_list[new_part_name] = SELF['partitions'][phys_dev]['part_list'][partition];
+        new_part_list[new_part_name] = SELF['partitions'][phys_dev]['size'][partition];
         new_part_num = new_part_num + 1;
       };
     };
@@ -498,8 +490,8 @@ variable DISK_PART_BY_DEV = {
         if ( listnum == 0 ) {              # Primary partitions
           if ( (length(no_size_list) > 1) ||
                ((length(no_size_list) == 1) &&
-                 is_defined(SELF['partitions'][phys_dev]['extended']) &&
-                 (no_size_list[0] != SELF['partitions'][phys_dev]['extended']) ) ) {
+                            is_defined(SELF['partitions'][phys_dev]['extended']) &&
+                            (no_size_list[0] != SELF['partitions'][phys_dev]['extended']) ) ) {
             if ( is_defined(SELF['partitions'][phys_dev]['extended']) ) {
               extended_msg='and 1 extended';
             } else {
@@ -533,45 +525,25 @@ variable DISK_PART_BY_DEV = {
     };
 
     # Assign the new list of partition for the device.
-    SELF['partitions'][phys_dev]['part_list'] = new_part_list;
+    SELF['partitions'][phys_dev]['size'] = new_part_list;
   };
-
-  debug(format('%s: renumbered partitions = %s', OBJECT, to_string(SELF['changed_part_num'])));
-  debug(format('%s: devices defined after partition renumbering = %s', OBJECT, to_string(SELF['partitions'])));
 
   SELF;
 };
 
-# Update DISK_VOLUME_PARAMS to reflect changed partition names/numbers in the device attribute for
-# partitions, VG and MD in order to be consistent with DISK_PART_BY_DEV. For VG and MD, it must be done
-# only if the device is not in DISK_VOLUME_PARAMS (partition automatically created in DISK_PART_BY_DEV).
+# Update DISK_VOLUME_PARAMS to reflect changed partition names/numbers.
+# This is done only for the device attribute in partition description,
+# no attempt is made to update volume names matching the partition.
 # A flag, 'final', is added to the entry to help with possible loops when processing
 # DISK_VOLUME_PARAMS: this flag explicitly states that this entry correspond to a
 # physical partition description and that no attempt should be made to dereference it.
 variable DISK_VOLUME_PARAMS = {
   foreach (volume;params;DISK_VOLUME_PARAMS) {
     if ( (params['type'] == 'partition') &&
-         is_defined(DISK_PART_BY_DEV['changed_part_num'][params['device']]) ) {
-      debug(format('%s: updating %s device to new partition name/number: %s', 
-                              OBJECT, volume, DISK_PART_BY_DEV['changed_part_num'][params['device']]));
+         (is_defined(DISK_PART_BY_DEV['changed_part_num'][params['device']])) ) {
+      debug('Updating '+volume+' partition to new name/number: '+DISK_PART_BY_DEV['changed_part_num'][params['device']]);
       params['device'] = DISK_PART_BY_DEV['changed_part_num'][params['device']];
       params['final'] = true;
-    } else if ( match(params['type'],'md|vg') ) {
-      dev_list = list();
-      dev_list_updated = false;
-      foreach(i;dev;params['devices']) {
-        if ( !is_defined(DISK_VOLUME_PARAMS[dev]) &&
-             is_defined(DISK_PART_BY_DEV['changed_part_num'][dev]) ) {
-          debug(format('%s: updating %s device %s to new partition name/number: %s', 
-                              OBJECT, volume, dev, DISK_PART_BY_DEV['changed_part_num'][dev]));
-          dev_list[length(dev_list)] = DISK_PART_BY_DEV['changed_part_num'][dev];
-          dev_list_updated = true;
-        } else {
-          dev_list[length(dev_list)] = dev;
-        };
-      };
-      if ( dev_list_updated ) debug(format('%s: %s new device list = %s', OBJECT, volume, to_string(dev_list)));
-      params['devices'] = dev_list;
     };
   };
   SELF;
@@ -596,9 +568,9 @@ variable DISK_VOLUME_PARAMS = {
     if ( is_defined(DISK_PART_BY_DEV['partitions'][phys_dev]['extended']) ) {
       extended_part = phys_dev + DISK_PART_BY_DEV['partitions'][phys_dev]['part_prefix'] +
                                             to_string(DISK_PART_BY_DEV['partitions'][phys_dev]['extended']);
-      partitions_add (phys_dev, params['part_list'], extended_part);
+      partitions_add (phys_dev, params, extended_part);
     } else {
-      partitions_add (phys_dev, params['part_list']);
+      partitions_add (phys_dev, params);
     };
   };
   SELF;


### PR DESCRIPTION
This PR provides the main part of the support for biosboot partitions (https://github.com/quattor/template-library-core/issues/72). It requires https://github.com/quattor/template-library-core/pull/126. The 2 PR altogether fix https://github.com/quattor/template-library-core/issues/72. In addition this PR brings UEFI support in the configuration description (also requires https://github.com/quattor/ncm-lib-blockdevices/issues/71 to be fixed for the actual support).

This PR contains also a some code refactoring/cleanup and several code fixes for long standing bugs uncovered when adding this new feature.

Heavily tested at LAL but tests by other sites are very welcome! 
