### PR TITLE
New Intel network card

### DIFF
--- a/hardware/nic/intel/x540.pan
+++ b/hardware/nic/intel/x540.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/intel/x540;
+
+'model' = 'x540';
+'manufacturer' = 'intel';
+'driver' = 'ixgbe';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Intel Corporation Ethernet Controller 10-Gigabit X540-AT2';
+'maxspeed' = 10000;


### PR DESCRIPTION
The Intel X540 card is a 10Gb Base-T network adapter.