### PR TITLE
Add hardware template for mellanox mt27710 nic.

### DIFF
--- a/hardware/nic/mellanox/mt27710.pan
+++ b/hardware/nic/mellanox/mt27710.pan
@@ -1,0 +1,10 @@
+structure template hardware/nic/mellanox/mt27710;
+
+'model' = 'mt27710';
+'manufacturer' = 'mellanox';
+'driver' = 'mlx5_core';
+'pxe' = false;
+'boot' = false;
+'media' = 'ethernet';
+'name' = 'Mellanox Technologies MT27710 Family [ConnectX-4 Lx]';
+'maxspeed' = 25000;


### PR DESCRIPTION
We have a new model of nic @ RAL that is not in the template library, so I am contributing it.

Best wishes,
Bruno