### PR TITLE
Add missing CPUs from Intel's ARK

### DIFF
--- a/hardware/cpu/intel/xeon_d_1513n.pan
+++ b/hardware/cpu/intel/xeon_d_1513n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1513n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU D-1513N @ 1.60 GHz";
+"speed" = 1600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "broadwell"; # Intel codename
+"power" = 35; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1523n.pan
+++ b/hardware/cpu/intel/xeon_d_1523n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1523n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU D-1523N @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "broadwell"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1533n.pan
+++ b/hardware/cpu/intel/xeon_d_1533n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1533n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU D-1533N @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "broadwell"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1543n.pan
+++ b/hardware/cpu/intel/xeon_d_1543n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1543n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU D-1543N @ 1.90 GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "broadwell"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1553n.pan
+++ b/hardware/cpu/intel/xeon_d_1553n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1553n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU D-1553N @ 2.30 GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "broadwell"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e6510.pan
+++ b/hardware/cpu/intel/xeon_e6510.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e6510;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU E6510 @ 1.73 GHz";
+"speed" = 1730; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "nehalem ex"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_e6540.pan
+++ b/hardware/cpu/intel/xeon_e6540.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e6540;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU E6540 @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "nehalem ex"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_e7520.pan
+++ b/hardware/cpu/intel/xeon_e7520.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e7520;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU E7520 @ 1.87 GHz";
+"speed" = 1870; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "nehalem ex"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_e7530.pan
+++ b/hardware/cpu/intel/xeon_e7530.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e7530;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU E7530 @ 1.87 GHz";
+"speed" = 1870; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "nehalem ex"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_e7540.pan
+++ b/hardware/cpu/intel/xeon_e7540.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e7540;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU E7540 @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "nehalem ex"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_l5618.pan
+++ b/hardware/cpu/intel/xeon_l5618.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_l5618;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU L5618 @ 1.87 GHz";
+"speed" = 1870; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "westmere ep"; # Intel codename
+"power" = 40; # TDP in watts

--- a/hardware/cpu/intel/xeon_l5638.pan
+++ b/hardware/cpu/intel/xeon_l5638.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_l5638;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU L5638 @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "westmere ep"; # Intel codename
+"power" = 60; # TDP in watts

--- a/hardware/cpu/intel/xeon_l7545.pan
+++ b/hardware/cpu/intel/xeon_l7545.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_l7545;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU L7545 @ 1.87 GHz";
+"speed" = 1870; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "nehalem ex"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_l7555.pan
+++ b/hardware/cpu/intel/xeon_l7555.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_l7555;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU L7555 @ 1.87 GHz";
+"speed" = 1870; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "nehalem ex"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_x6550.pan
+++ b/hardware/cpu/intel/xeon_x6550.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_x6550;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU X6550 @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "nehalem ex"; # Intel codename
+"power" = 130; # TDP in watts

--- a/hardware/cpu/intel/xeon_x7542.pan
+++ b/hardware/cpu/intel/xeon_x7542.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_x7542;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU X7542 @ 2.67 GHz";
+"speed" = 2670; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 6;
+"type" = "nehalem ex"; # Intel codename
+"power" = 130; # TDP in watts

--- a/hardware/cpu/intel/xeon_x7550.pan
+++ b/hardware/cpu/intel/xeon_x7550.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_x7550;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU X7550 @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "nehalem ex"; # Intel codename
+"power" = 130; # TDP in watts

--- a/hardware/cpu/intel/xeon_x7560.pan
+++ b/hardware/cpu/intel/xeon_x7560.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_x7560;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU X7560 @ 2.27 GHz";
+"speed" = 2270; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "nehalem ex"; # Intel codename
+"power" = 130; # TDP in watts


### PR DESCRIPTION
These were being ignored due to missing architecture information in ARK,
but this can be inferred from the CPU feature set.