### PR TITLE
Add new Intel Xeon Scalable Processors from ARK

### DIFF
--- a/hardware/cpu/intel/xeon_bronze_3104.pan
+++ b/hardware/cpu/intel/xeon_bronze_3104.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_bronze_3104;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Bronze 3104 CPU @ 1.70 GHz";
+"speed" = 1700; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 6;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_bronze_3106.pan
+++ b/hardware/cpu/intel/xeon_bronze_3106.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_bronze_3106;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Bronze 3106 CPU @ 1.70 GHz";
+"speed" = 1700; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 8;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5115.pan
+++ b/hardware/cpu/intel/xeon_gold_5115.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5115;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5115 CPU @ 2.40 GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5118.pan
+++ b/hardware/cpu/intel/xeon_gold_5118.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5118;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5118 CPU @ 2.30 GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5119t.pan
+++ b/hardware/cpu/intel/xeon_gold_5119t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5119t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5119T CPU @ 1.90 GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 14;
+"max_threads" = 28;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5120.pan
+++ b/hardware/cpu/intel/xeon_gold_5120.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5120;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5120 CPU @ 2.20 GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 14;
+"max_threads" = 28;
+"type" = "skylake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5120t.pan
+++ b/hardware/cpu/intel/xeon_gold_5120t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5120t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5120T CPU @ 2.20 GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 14;
+"max_threads" = 28;
+"type" = "skylake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5122.pan
+++ b/hardware/cpu/intel/xeon_gold_5122.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5122;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5122 CPU @ 3.60 GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "skylake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6126.pan
+++ b/hardware/cpu/intel/xeon_gold_6126.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6126;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6126 CPU @ 2.60 GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6126f.pan
+++ b/hardware/cpu/intel/xeon_gold_6126f.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6126f;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6126F CPU @ 2.60 GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 135; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6126t.pan
+++ b/hardware/cpu/intel/xeon_gold_6126t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6126t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6126T CPU @ 2.60 GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6128.pan
+++ b/hardware/cpu/intel/xeon_gold_6128.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6128;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6128 CPU @ 3.40 GHz";
+"speed" = 3400; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "skylake"; # Intel codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6130.pan
+++ b/hardware/cpu/intel/xeon_gold_6130.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6130;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6130 CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6130f.pan
+++ b/hardware/cpu/intel/xeon_gold_6130f.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6130f;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6130F CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 135; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6130t.pan
+++ b/hardware/cpu/intel/xeon_gold_6130t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6130t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6130T CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6132.pan
+++ b/hardware/cpu/intel/xeon_gold_6132.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6132;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6132 CPU @ 2.60 GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 14;
+"max_threads" = 28;
+"type" = "skylake"; # Intel codename
+"power" = 140; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6134.pan
+++ b/hardware/cpu/intel/xeon_gold_6134.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6134;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6134 CPU @ 3.20 GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 130; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6134m.pan
+++ b/hardware/cpu/intel/xeon_gold_6134m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6134m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6134M CPU @ 3.20 GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 130; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6136.pan
+++ b/hardware/cpu/intel/xeon_gold_6136.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6136;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6136 CPU @ 3.00 GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6138.pan
+++ b/hardware/cpu/intel/xeon_gold_6138.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6138;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6138 CPU @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "skylake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6138f.pan
+++ b/hardware/cpu/intel/xeon_gold_6138f.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6138f;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6138F CPU @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "skylake"; # Intel codename
+"power" = 135; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6138t.pan
+++ b/hardware/cpu/intel/xeon_gold_6138t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6138t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6138T CPU @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "skylake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6140.pan
+++ b/hardware/cpu/intel/xeon_gold_6140.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6140;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6140 CPU @ 2.30 GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "skylake"; # Intel codename
+"power" = 140; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6140m.pan
+++ b/hardware/cpu/intel/xeon_gold_6140m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6140m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6140M CPU @ 2.30 GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "skylake"; # Intel codename
+"power" = 140; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6142.pan
+++ b/hardware/cpu/intel/xeon_gold_6142.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6142;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6142 CPU @ 2.60 GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6142f.pan
+++ b/hardware/cpu/intel/xeon_gold_6142f.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6142f;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6142F CPU @ 2.60 GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 160; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6142m.pan
+++ b/hardware/cpu/intel/xeon_gold_6142m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6142m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6142M CPU @ 2.60 GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6144.pan
+++ b/hardware/cpu/intel/xeon_gold_6144.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6144;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6144 CPU @ 3.50 GHz";
+"speed" = 3500; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6146.pan
+++ b/hardware/cpu/intel/xeon_gold_6146.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6146;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6146 CPU @ 3.20 GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6148.pan
+++ b/hardware/cpu/intel/xeon_gold_6148.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6148;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6148 CPU @ 2.40 GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6148f.pan
+++ b/hardware/cpu/intel/xeon_gold_6148f.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6148f;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6148F CPU @ 2.40 GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "skylake"; # Intel codename
+"power" = 160; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6150.pan
+++ b/hardware/cpu/intel/xeon_gold_6150.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6150;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6150 CPU @ 2.70 GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "skylake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6152.pan
+++ b/hardware/cpu/intel/xeon_gold_6152.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6152;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6152 CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 22;
+"max_threads" = 44;
+"type" = "skylake"; # Intel codename
+"power" = 140; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6154.pan
+++ b/hardware/cpu/intel/xeon_gold_6154.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6154;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6154 CPU @ 3.00 GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "skylake"; # Intel codename
+"power" = 200; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8153.pan
+++ b/hardware/cpu/intel/xeon_platinum_8153.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8153;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8153 CPU @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8156.pan
+++ b/hardware/cpu/intel/xeon_platinum_8156.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8156;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8156 CPU @ 3.60 GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "skylake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8158.pan
+++ b/hardware/cpu/intel/xeon_platinum_8158.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8158;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8158 CPU @ 3.00 GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8160.pan
+++ b/hardware/cpu/intel/xeon_platinum_8160.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8160;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8160 CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8160f.pan
+++ b/hardware/cpu/intel/xeon_platinum_8160f.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8160f;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8160F CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "skylake"; # Intel codename
+"power" = 160; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8160m.pan
+++ b/hardware/cpu/intel/xeon_platinum_8160m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8160m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8160M CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8160t.pan
+++ b/hardware/cpu/intel/xeon_platinum_8160t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8160t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8160T CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8164.pan
+++ b/hardware/cpu/intel/xeon_platinum_8164.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8164;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8164 CPU @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 26;
+"max_threads" = 52;
+"type" = "skylake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8168.pan
+++ b/hardware/cpu/intel/xeon_platinum_8168.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8168;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8168 CPU @ 2.70 GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "skylake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8170.pan
+++ b/hardware/cpu/intel/xeon_platinum_8170.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8170;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8170 CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 26;
+"max_threads" = 52;
+"type" = "skylake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8170m.pan
+++ b/hardware/cpu/intel/xeon_platinum_8170m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8170m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8170M CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 26;
+"max_threads" = 52;
+"type" = "skylake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8176.pan
+++ b/hardware/cpu/intel/xeon_platinum_8176.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8176;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8176 CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "skylake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8176f.pan
+++ b/hardware/cpu/intel/xeon_platinum_8176f.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8176f;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8176F CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "skylake"; # Intel codename
+"power" = 173; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8176m.pan
+++ b/hardware/cpu/intel/xeon_platinum_8176m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8176m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8176M CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "skylake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8180.pan
+++ b/hardware/cpu/intel/xeon_platinum_8180.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8180;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50 GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "skylake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8180m.pan
+++ b/hardware/cpu/intel/xeon_platinum_8180m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8180m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8180M CPU @ 2.50 GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "skylake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4108.pan
+++ b/hardware/cpu/intel/xeon_silver_4108.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4108;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4108 CPU @ 1.80 GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4109t.pan
+++ b/hardware/cpu/intel/xeon_silver_4109t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4109t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4109T CPU @ 2.00 GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 70; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4110.pan
+++ b/hardware/cpu/intel/xeon_silver_4110.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4110;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4110 CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4112.pan
+++ b/hardware/cpu/intel/xeon_silver_4112.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4112;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4112 CPU @ 2.60 GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4114.pan
+++ b/hardware/cpu/intel/xeon_silver_4114.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4114;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4114 CPU @ 2.20 GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4114t.pan
+++ b/hardware/cpu/intel/xeon_silver_4114t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4114t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4114T CPU @ 2.20 GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4116.pan
+++ b/hardware/cpu/intel/xeon_silver_4116.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4116;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4116 CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4116t.pan
+++ b/hardware/cpu/intel/xeon_silver_4116t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4116t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4116T CPU @ 2.10 GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts


### PR DESCRIPTION
The new numbering scheme for Scalable processors collides with the numbering
of the Woodcrest Xeon range, so we are using the brand modifier is used as a
prefix to differentiate them.