### PR TITLE
Add new AMD EPYC processors

### DIFF
--- a/hardware/cpu/amd/epyc_7251.pan
+++ b/hardware/cpu/amd/epyc_7251.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7251;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7251 8-Core Processor";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "zen"; # AMD codename
+"power" = 120; # TDP in watts

--- a/hardware/cpu/amd/epyc_7281.pan
+++ b/hardware/cpu/amd/epyc_7281.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7281;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7281 16-Core Processor";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "zen"; # AMD codename
+"power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7301.pan
+++ b/hardware/cpu/amd/epyc_7301.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7301;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7301 16-Core Processor";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "zen"; # AMD codename
+"power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7351.pan
+++ b/hardware/cpu/amd/epyc_7351.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7351;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7351 16-Core Processor";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "zen"; # AMD codename
+"power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7351p.pan
+++ b/hardware/cpu/amd/epyc_7351p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7351p;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7351P 16-Core Processor";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "zen"; # AMD codename
+"power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7401.pan
+++ b/hardware/cpu/amd/epyc_7401.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7401;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7401 24-Core Processor";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "zen"; # AMD codename
+"power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7401p.pan
+++ b/hardware/cpu/amd/epyc_7401p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7401p;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7401P 24-Core Processor";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "zen"; # AMD codename
+"power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7451.pan
+++ b/hardware/cpu/amd/epyc_7451.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7451;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7451 24-Core Processor";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "zen"; # AMD codename
+"power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7501.pan
+++ b/hardware/cpu/amd/epyc_7501.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7501;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7501 32-Core Processor";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "zen"; # AMD codename
+"power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7551.pan
+++ b/hardware/cpu/amd/epyc_7551.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7551;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7551 32-Core Processor";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "zen"; # AMD codename
+"power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7551p.pan
+++ b/hardware/cpu/amd/epyc_7551p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7551p;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7551P 32-Core Processor";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "zen"; # AMD codename
+"power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7601.pan
+++ b/hardware/cpu/amd/epyc_7601.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_7601;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 7601 32-Core Processor";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "zen"; # AMD codename
+"power" = 180; # TDP in watts


### PR DESCRIPTION
Based on information from the official spec sheets.

We haven't got any of these yet, so cannot verify that the `model` string matches what `/proc/cpuinfo` will say, but it agrees with the only publicly available dump that I managed to find.