### PR TITLE
Add last two generations of AMD Opteron CPUs

### DIFF
--- a/hardware/cpu/amd/opteron_6308.pan
+++ b/hardware/cpu/amd/opteron_6308.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6308;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6308";
+"speed" = 3500; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "piledriver"; # AMD codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/amd/opteron_6320.pan
+++ b/hardware/cpu/amd/opteron_6320.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6320;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6320";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 8;
+"type" = "piledriver"; # AMD codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/amd/opteron_6328.pan
+++ b/hardware/cpu/amd/opteron_6328.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6328;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6328";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 8;
+"type" = "piledriver"; # AMD codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/amd/opteron_6338p.pan
+++ b/hardware/cpu/amd/opteron_6338p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6338p;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6338P";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 12;
+"type" = "piledriver"; # AMD codename
+"power" = 99; # TDP in watts

--- a/hardware/cpu/amd/opteron_6344.pan
+++ b/hardware/cpu/amd/opteron_6344.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6344;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6344";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 12;
+"type" = "piledriver"; # AMD codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/amd/opteron_6348.pan
+++ b/hardware/cpu/amd/opteron_6348.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6348;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6348";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 12;
+"type" = "piledriver"; # AMD codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/amd/opteron_6366he.pan
+++ b/hardware/cpu/amd/opteron_6366he.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6366he;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6366 HE";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 16;
+"type" = "piledriver"; # AMD codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/amd/opteron_6370p.pan
+++ b/hardware/cpu/amd/opteron_6370p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6370p;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6370P";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 16;
+"type" = "piledriver"; # AMD codename
+"power" = 99; # TDP in watts

--- a/hardware/cpu/amd/opteron_6376.pan
+++ b/hardware/cpu/amd/opteron_6376.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6376;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6376";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 16;
+"type" = "piledriver"; # AMD codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/amd/opteron_6378.pan
+++ b/hardware/cpu/amd/opteron_6378.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6378;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6378";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 16;
+"type" = "piledriver"; # AMD codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/amd/opteron_6380.pan
+++ b/hardware/cpu/amd/opteron_6380.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6380;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6380";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 16;
+"type" = "piledriver"; # AMD codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/amd/opteron_6386se.pan
+++ b/hardware/cpu/amd/opteron_6386se.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_6386se;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor 6386 SE";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 16;
+"type" = "piledriver"; # AMD codename
+"power" = 140; # TDP in watts

--- a/hardware/cpu/amd/opteron_x2150.pan
+++ b/hardware/cpu/amd/opteron_x2150.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_x2150;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor X2150";
+"speed" = 1100; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "jaguar"; # AMD codename
+"power" = 22; # TDP in watts

--- a/hardware/cpu/amd/opteron_x2170.pan
+++ b/hardware/cpu/amd/opteron_x2170.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_x2170;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor X2170";
+"speed" = 1000; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "jaguar"; # AMD codename
+"power" = 25; # TDP in watts

--- a/hardware/cpu/amd/opteron_x3216.pan
+++ b/hardware/cpu/amd/opteron_x3216.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_x3216;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor X3216";
+"speed" = 1600; # MHz
+"arch" = "x86_64";
+"cores" = 2;
+"max_threads" = 2;
+"type" = "jaguar"; # AMD codename
+"power" = 15; # TDP in watts

--- a/hardware/cpu/amd/opteron_x3418.pan
+++ b/hardware/cpu/amd/opteron_x3418.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_x3418;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor X3418";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "jaguar"; # AMD codename
+"power" = 35; # TDP in watts

--- a/hardware/cpu/amd/opteron_x3421.pan
+++ b/hardware/cpu/amd/opteron_x3421.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/opteron_x3421;
+
+"manufacturer" = "AMD";
+"model" = "AMD Opteron(tm) Processor X3421";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "jaguar"; # AMD codename
+"power" = 35; # TDP in watts


### PR DESCRIPTION
Based on information from AMDs public spec sheets and verified against publicly available `/proc/cpuinfo` dumps.