### PR TITLE
Add CPUs used in Mellanox SN2100 and SN2700 switches

### DIFF
--- a/hardware/cpu/intel/atom_c2558.pan
+++ b/hardware/cpu/intel/atom_c2558.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/atom_c2558;
+
+"manufacturer" = "Intel";
+"model" = "Intel Atom(R) CPU C2558 @ 2.40 GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "rangeley"; # Intel codename
+"power" = 15; # TDP in watts

--- a/hardware/cpu/intel/celeron_1047ue.pan
+++ b/hardware/cpu/intel/celeron_1047ue.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/celeron_1047ue;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Celeron(R) CPU 1047UE @ 1.40 GHz";
+"speed" = 1400; # MHz
+"arch" = "x86_64";
+"cores" = 2;
+"max_threads" = 2;
+"type" = "ivy bridge"; # Intel codename
+"power" = 17; # TDP in watts


### PR DESCRIPTION
Individually generated with ark2pan.

As requested by @apdibbo, resolves #103.