### PR TITLE
Set bnx2x boot parameter to false

### DIFF
--- a/hardware/nic/by_driver/bnx2x.pan
+++ b/hardware/nic/by_driver/bnx2x.pan
@@ -2,7 +2,7 @@ structure template hardware/nic/by_driver/bnx2x;
 
 "driver" = "bnx2x";
 "pxe"    = true;
-"boot"   = true;
+"boot"   = false;
 "media"  = "Ethernet";
 "name"   = "QLogic Everest network driver";
 "manufacturer" = "broadcom";


### PR DESCRIPTION
This fixes an issue where the bnx2x is not the primary card.

All network cards have the boot parameters set to 'false', only the bnx2x not. In the case where we want to boot from another nic than bnx2x in a server, we get a configuration issue, as the boot interface is not correctly set.