### PR TITLE
Add sample of nvidia workstation and compute GPUs

### DIFF
--- a/hardware/card/gpu/nvidia/quadro_gp100.pan
+++ b/hardware/card/gpu/nvidia/quadro_gp100.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_gp100;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_gp100';
+'model' = 'GP100';
+'power' = 235; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 16384; # MB
+'ram/bus' = '4096-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x15f0;

--- a/hardware/card/gpu/nvidia/quadro_k1200.pan
+++ b/hardware/card/gpu/nvidia/quadro_k1200.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_k1200;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_k1200';
+'model' = 'GM107';
+'power' = 45; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 4096; # MB
+'ram/bus' = '128-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x13bc;

--- a/hardware/card/gpu/nvidia/quadro_k2200.pan
+++ b/hardware/card/gpu/nvidia/quadro_k2200.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_k2200;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_k2200';
+'model' = 'GM107';
+'power' = 68; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 4096; # MB
+'ram/bus' = '128-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x13ba;

--- a/hardware/card/gpu/nvidia/quadro_k420.pan
+++ b/hardware/card/gpu/nvidia/quadro_k420.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_k420;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_k420';
+'model' = 'GK107';
+'power' = 41; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 1024; # MB
+'ram/bus' = '128-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x0ff3;

--- a/hardware/card/gpu/nvidia/quadro_k4200.pan
+++ b/hardware/card/gpu/nvidia/quadro_k4200.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_k4200;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_k4200';
+'model' = 'GK104';
+'power' = 108; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 4096; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x11b4;

--- a/hardware/card/gpu/nvidia/quadro_k5200.pan
+++ b/hardware/card/gpu/nvidia/quadro_k5200.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_k5200;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_k5200';
+'model' = 'GK110B';
+'power' = 150; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x103c;

--- a/hardware/card/gpu/nvidia/quadro_k620.pan
+++ b/hardware/card/gpu/nvidia/quadro_k620.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_k620;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_k620';
+'model' = 'GM107';
+'power' = 41; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 2048; # MB
+'ram/bus' = '128-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x13bb;

--- a/hardware/card/gpu/nvidia/quadro_m2000.pan
+++ b/hardware/card/gpu/nvidia/quadro_m2000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_m2000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_m2000';
+'model' = 'GM206';
+'power' = 75; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 4096; # MB
+'ram/bus' = '128-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1430;

--- a/hardware/card/gpu/nvidia/quadro_m3000_se.pan
+++ b/hardware/card/gpu/nvidia/quadro_m3000_se.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_m3000_se;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_m3000_se';
+'model' = 'GM204';
+'power' = 75; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 4096; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x13fa;

--- a/hardware/card/gpu/nvidia/quadro_m4000.pan
+++ b/hardware/card/gpu/nvidia/quadro_m4000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_m4000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_m4000';
+'model' = 'GM204';
+'power' = 120; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x13f1;

--- a/hardware/card/gpu/nvidia/quadro_m5000.pan
+++ b/hardware/card/gpu/nvidia/quadro_m5000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_m5000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_m5000';
+'model' = 'GM204';
+'power' = 150; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x13f0;

--- a/hardware/card/gpu/nvidia/quadro_m6000.pan
+++ b/hardware/card/gpu/nvidia/quadro_m6000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_m6000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_m6000';
+'model' = 'GM200';
+'power' = 250; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 12288; # MB
+'ram/bus' = '384-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x17f0;

--- a/hardware/card/gpu/nvidia/quadro_m6000_24gb.pan
+++ b/hardware/card/gpu/nvidia/quadro_m6000_24gb.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_m6000_24gb;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_m6000_24gb';
+'model' = 'GM200';
+'power' = 250; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 24576; # MB
+'ram/bus' = '384-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x17f1;

--- a/hardware/card/gpu/nvidia/quadro_p1000.pan
+++ b/hardware/card/gpu/nvidia/quadro_p1000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_p1000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_p1000';
+'model' = 'GP107';
+'power' = 47; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 4096; # MB
+'ram/bus' = '128-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1cb1;

--- a/hardware/card/gpu/nvidia/quadro_p2000.pan
+++ b/hardware/card/gpu/nvidia/quadro_p2000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_p2000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_p2000';
+'model' = 'GP106';
+'power' = 75; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 5120; # MB
+'ram/bus' = '160-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1c30;

--- a/hardware/card/gpu/nvidia/quadro_p400.pan
+++ b/hardware/card/gpu/nvidia/quadro_p400.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_p400;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_p400';
+'model' = 'GP107';
+'power' = 30; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 2048; # MB
+'ram/bus' = '64-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1cb3;

--- a/hardware/card/gpu/nvidia/quadro_p4000.pan
+++ b/hardware/card/gpu/nvidia/quadro_p4000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_p4000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_p4000';
+'model' = 'GP104';
+'power' = 105; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1bb1;

--- a/hardware/card/gpu/nvidia/quadro_p500.pan
+++ b/hardware/card/gpu/nvidia/quadro_p500.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_p500;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_p500';
+'model' = 'GP108';
+'power' = 30; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 2048; # MB
+'ram/bus' = '64-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1d33;

--- a/hardware/card/gpu/nvidia/quadro_p5000.pan
+++ b/hardware/card/gpu/nvidia/quadro_p5000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_p5000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_p5000';
+'model' = 'GP104';
+'power' = 180; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 16384; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1bb0;

--- a/hardware/card/gpu/nvidia/quadro_p600.pan
+++ b/hardware/card/gpu/nvidia/quadro_p600.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_p600;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_p600';
+'model' = 'GP107';
+'power' = 40; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 2048; # MB
+'ram/bus' = '128-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1cb2;

--- a/hardware/card/gpu/nvidia/quadro_p6000.pan
+++ b/hardware/card/gpu/nvidia/quadro_p6000.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/quadro_p6000;
+
+'manufacturer' = 'nvidia';
+'name' = 'quadro_p6000';
+'model' = 'GP102';
+'power' = 250; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 24576; # MB
+'ram/bus' = '384-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1b30;

--- a/hardware/card/gpu/nvidia/tesla_k8.pan
+++ b/hardware/card/gpu/nvidia/tesla_k8.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_k8;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_k8';
+'model' = 'GK104';
+'power' = 100; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1194;

--- a/hardware/card/gpu/nvidia/tesla_k80.pan
+++ b/hardware/card/gpu/nvidia/tesla_k80.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_k80;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_k80';
+'model' = 'GK210';
+'power' = 300; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 12288; # MB
+'ram/bus' = '384-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x102d;

--- a/hardware/card/gpu/nvidia/tesla_m10.pan
+++ b/hardware/card/gpu/nvidia/tesla_m10.pan
@@ -1,0 +1,10 @@
+structure template hardware/card/gpu/nvidia/tesla_m10;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_m10';
+'model' = 'GM107';
+'power' = 225; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '128-bit';

--- a/hardware/card/gpu/nvidia/tesla_m4.pan
+++ b/hardware/card/gpu/nvidia/tesla_m4.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_m4;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_m4';
+'model' = 'GM206';
+'power' = 50; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 4096; # MB
+'ram/bus' = '128-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1431;

--- a/hardware/card/gpu/nvidia/tesla_m40.pan
+++ b/hardware/card/gpu/nvidia/tesla_m40.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_m40;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_m40';
+'model' = 'GM200';
+'power' = 250; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 12288; # MB
+'ram/bus' = '384-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x17fd;

--- a/hardware/card/gpu/nvidia/tesla_m6.pan
+++ b/hardware/card/gpu/nvidia/tesla_m6.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_m6;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_m6';
+'model' = 'GM204';
+'power' = 100; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x13f3;

--- a/hardware/card/gpu/nvidia/tesla_m60.pan
+++ b/hardware/card/gpu/nvidia/tesla_m60.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_m60;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_m60';
+'model' = 'GM204';
+'power' = 300; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x13f2;

--- a/hardware/card/gpu/nvidia/tesla_p100-pcie-12gb.pan
+++ b/hardware/card/gpu/nvidia/tesla_p100-pcie-12gb.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_p100-pcie-12gb;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_p100-pcie-12gb';
+'model' = 'GP100';
+'power' = 300; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 12288; # MB
+'ram/bus' = '4096-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x15f7;

--- a/hardware/card/gpu/nvidia/tesla_p100-pcie-16gb.pan
+++ b/hardware/card/gpu/nvidia/tesla_p100-pcie-16gb.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_p100-pcie-16gb;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_p100-pcie-16gb';
+'model' = 'GP100';
+'power' = 300; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 16384; # MB
+'ram/bus' = '4096-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x15f8;

--- a/hardware/card/gpu/nvidia/tesla_p100-sxm2-16gb.pan
+++ b/hardware/card/gpu/nvidia/tesla_p100-sxm2-16gb.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_p100-sxm2-16gb;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_p100-sxm2-16gb';
+'model' = 'GP100';
+'power' = 300; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 16384; # MB
+'ram/bus' = '4096-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x15f9;

--- a/hardware/card/gpu/nvidia/tesla_p4.pan
+++ b/hardware/card/gpu/nvidia/tesla_p4.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_p4;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_p4';
+'model' = 'GP104';
+'power' = 75; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 8192; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1bb3;

--- a/hardware/card/gpu/nvidia/tesla_p40.pan
+++ b/hardware/card/gpu/nvidia/tesla_p40.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_p40;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_p40';
+'model' = 'GP102';
+'power' = 250; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 24576; # MB
+'ram/bus' = '384-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1b38;

--- a/hardware/card/gpu/nvidia/tesla_p6.pan
+++ b/hardware/card/gpu/nvidia/tesla_p6.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_p6;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_p6';
+'model' = 'GP104';
+'power' = 90; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 16384; # MB
+'ram/bus' = '256-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1bb4;

--- a/hardware/card/gpu/nvidia/tesla_v100-pcie-16gb.pan
+++ b/hardware/card/gpu/nvidia/tesla_v100-pcie-16gb.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_v100-pcie-16gb;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_v100-pcie-16gb';
+'model' = 'GV100';
+'power' = 250; # TDP in watts
+'bus' = 'PCIe';
+
+'ram/size' = 16384; # MB
+'ram/bus' = '4096-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1db4;

--- a/hardware/card/gpu/nvidia/tesla_v100-sxm2-16gb.pan
+++ b/hardware/card/gpu/nvidia/tesla_v100-sxm2-16gb.pan
@@ -1,0 +1,14 @@
+structure template hardware/card/gpu/nvidia/tesla_v100-sxm2-16gb;
+
+'manufacturer' = 'nvidia';
+'name' = 'tesla_v100-sxm2-16gb';
+'model' = 'GV100';
+'power' = 300; # TDP in watts
+'bus' = 'NVLink';
+
+'ram/size' = 16384; # MB
+'ram/bus' = '4096-bit';
+
+'pci/class' = 0x030000; # Display controller, VGA compatible.
+'pci/vendor' = 0x10de; # nVidia Corporation
+'pci/device' = 0x1db1;


### PR DESCRIPTION
This is a proposal for shipping upstream templates for commonly used GPU cards.

To support this the hardware schema would need to be updated to support modelling RAM on GPU cards, see quattor/template-library-core#172 for the PR that implements this.

The information in these templates was gathered from a variety of on-line resources and munged into templates with a script based on https://github.com/jrha/ark2pan. Much more information (e.g. various clock speeds, number of shading units etc.) is potentially available but is probably not useful to include here.

Requires quattor/template-library-core#172.