### PR TITLE
features/docker/config: fix compatibility with panc 10.7

### DIFF
--- a/features/docker/config.pan
+++ b/features/docker/config.pan
@@ -19,10 +19,10 @@ variable DOCKER_PIPEWORK ?= false;
 @{
 descr = YUM repository containing Docker packages
 values = string
-default = null
+default = undef
 required = No
 }
-variable DOCKER_YUM_REPOSITORY ?= null;
+variable DOCKER_YUM_REPOSITORY ?= undef;
 
 @{
 descr = name of the Docker package
@@ -30,7 +30,7 @@ values = string
 default = depends on the OS version
 required = No
 }
-variable DOCKER_PACKAGE ?= null;
+variable DOCKER_PACKAGE ?= undef;
 
 @{
 descr = list of Docker related groups

--- a/features/docker/config.pan
+++ b/features/docker/config.pan
@@ -27,7 +27,7 @@ variable DOCKER_YUM_REPOSITORY ?= undef;
 @{
 descr = name of the Docker package
 values = string
-default = depends on the OS version
+default = undef (but actual default is set by the Docker template for the OS verion)
 required = No
 }
 variable DOCKER_PACKAGE ?= undef;


### PR DESCRIPTION
- In panc 10.7, null is no longer considered an undefined value (see https://github.com/quattor/pan/pull/175)