### PR TITLE
fetch-crl : avoid unnecessary run of fetch-crl-boot

### DIFF
--- a/features/fetch-crl/config.pan
+++ b/features/fetch-crl/config.pan
@@ -46,17 +46,6 @@ bind '/software/components/metaconfig/services/{/etc/sysconfig/fetch-crl}/conten
 
 
 # ----------------------------------------------------------------------------
-# chkconfig
+# fetch-crl services configuration (OS-dependent)
 # ----------------------------------------------------------------------------
-include "components/chkconfig/config";
-"/software/components/chkconfig/service" = {
-    # Run fetch-crl on boot
-    SELF[escape('fetch-crl-boot')] = dict("on", "",
-                                        "startstop", true);
-
-    # Enable periodic fetch-crl (cron)
-    SELF[escape('fetch-crl-cron')] = dict("on", "",
-                                        "startstop", true);
-
-    SELF;
-};
+include format('features/fetch-crl/%s/config', OS_VERSION_PARAMS['major']);

--- a/features/fetch-crl/config.pan
+++ b/features/fetch-crl/config.pan
@@ -13,8 +13,7 @@ variable SITE_DEF_HOST_KEY ?= SITE_DEF_GRIDSEC_ROOT + "/hostkey.pem";
 variable SITE_DEF_CERTDIR ?= SITE_DEF_GRIDSEC_ROOT + "/certificates";
 
 # Include RPMs
-variable RPMS_CONFIG_SUFFIX ?= '';
-include 'features/fetch-crl/rpms' + RPMS_CONFIG_SUFFIX;
+include 'features/fetch-crl/rpms';
 
 # ----------------------------------------------------------------------------
 # fetch-crl configuration

--- a/features/fetch-crl/el7/config.pan
+++ b/features/fetch-crl/el7/config.pan
@@ -1,0 +1,18 @@
+
+unique template features/fetch-crl/el7/config;
+
+
+include 'components/systemd/config';
+
+'/software/components/systemd/skip/service' = false;
+
+# This is a customization file
+'/software/components/systemd/unit/fetch-crl-boot/file/replace' = false;
+
+# Fix for issue https://bugzilla.redhat.com/show_bug.cgi?id=1630027
+prefix '/software/components/systemd/unit/fetch-crl-boot/file/config/service';
+'RemainAfterExit' = true;
+
+# Enable fetch-crl CRON
+prefix '/software/components/systemd/unit/fetch-crl-cron';
+'state' = 'enabled';

--- a/features/fetch-crl/el7/config.pan
+++ b/features/fetch-crl/el7/config.pan
@@ -6,13 +6,22 @@ include 'components/systemd/config';
 
 '/software/components/systemd/skip/service' = false;
 
-# This is a customization file
-'/software/components/systemd/unit/fetch-crl-boot/file/replace' = false;
+##################
+# fetch-crl-boot #
+##################
+
+prefix '/software/components/systemd/unit/fetch-crl-boot';
 
 # Fix for issue https://bugzilla.redhat.com/show_bug.cgi?id=1630027
-prefix '/software/components/systemd/unit/fetch-crl-boot/file/config/service';
-'RemainAfterExit' = true;
+# Create a customization file
+'file/replace' = false;
+'file/config/service/RemainAfterExit' = true;
 
-# Enable fetch-crl CRON
+
+##################
+# fetch-crl-cron #
+##################
+
+# Enable fetch-crl-cron
 prefix '/software/components/systemd/unit/fetch-crl-cron';
 'state' = 'enabled';

--- a/features/fetch-crl/rpms-yd.pan
+++ b/features/fetch-crl/rpms-yd.pan
@@ -1,3 +1,0 @@
-unique template features/fetch-crl/rpms-yd;
-
-"/software/packages/{fetch-crl}" ?= nlist();

--- a/features/fetch-crl/rpms.pan
+++ b/features/fetch-crl/rpms.pan
@@ -1,3 +1,3 @@
 unique template features/fetch-crl/rpms;
 
-"/software/packages/{fetch-crl}" ?= nlist();
+"/software/packages/{fetch-crl}" ?= dict();

--- a/features/fetch-crl/rpms.pan
+++ b/features/fetch-crl/rpms.pan
@@ -1,19 +1,3 @@
 unique template features/fetch-crl/rpms;
 
-variable FETCH_CRL_RPM_NAME ?= 'fetch-crl';
-variable FETCH_CRL_VERSION ?= {
-    if (match(OS_VERSION_PARAMS['major'], '[es]l6')) {
-        '3.0.8-1.el6';
-    } else if (match(OS_VERSION_PARAMS['major'], '[es]l5')) {
-        '2.8.5-1.el5';
-    } else if (OS_VERSION_PARAMS['major'] == 'fedora14') {
-        '2.8.5-1.el5';
-    } else {
-        '2.7.0-2';
-    };
-};
-
-'/software/packages' = {
-    debug(FULL_HOSTNAME+': adding fetch-crl version '+FETCH_CRL_VERSION+' (OS:'+OS_VERSION_PARAMS['major']+', RPM name:'+FETCH_CRL_RPM_NAME+')');
-    pkg_repl(FETCH_CRL_RPM_NAME, FETCH_CRL_VERSION, 'noarch');
-};
+"/software/packages/{fetch-crl}" ?= nlist();

--- a/features/fetch-crl/sl6/config.pan
+++ b/features/fetch-crl/sl6/config.pan
@@ -1,15 +1,12 @@
 unique template features/fetch-crl/sl6/config;
 
 include "components/chkconfig/config";
-"/software/components/chkconfig/service" = {
-    # Run fetch-crl on boot
-    SELF[escape('fetch-crl-boot')] = dict("on", "",
-                                        "startstop", true);
+"/software/components/chkconfig/service/{fetch-crl-boot}" = dict(
+    "on", "",
+    "startstop", true,
+);
 
-    # Enable periodic fetch-crl (cron)
-    SELF[escape('fetch-crl-cron')] = dict("on", "",
-                                        "startstop", true);
-
-    SELF;
-};
-
+"/software/components/chkconfig/service/{fetch-crl-cron}" = dict(
+    "on", "",
+    "startstop", true,
+);

--- a/features/fetch-crl/sl6/config.pan
+++ b/features/fetch-crl/sl6/config.pan
@@ -1,0 +1,15 @@
+unique template features/fetch-crl/sl6/config;
+
+include "components/chkconfig/config";
+"/software/components/chkconfig/service" = {
+    # Run fetch-crl on boot
+    SELF[escape('fetch-crl-boot')] = dict("on", "",
+                                        "startstop", true);
+
+    # Enable periodic fetch-crl (cron)
+    SELF[escape('fetch-crl-cron')] = dict("on", "",
+                                        "startstop", true);
+
+    SELF;
+};
+


### PR DESCRIPTION
Workaround for issue https://bugzilla.redhat.com/show_bug.cgi?id=1630027 that will be harmless if/when the bug is fixed.

This PR also removes the support for `fetch-crl` deployment with SPMA.
