### PR TITLE
CVMFS: autofs configuration made mandatory

### DIFF
--- a/features/cvmfs/client.pan
+++ b/features/cvmfs/client.pan
@@ -107,25 +107,18 @@ include 'components/chkconfig/config';
 
 
 #
-# Configure autofs component, if already included
+# Configure autofs component
 #
 include 'components/autofs/config';
-'/software/components' = {
-    if (exists('/software/components/autofs/maps')) {
-        autofs = SELF['autofs'];
-        if(!is_defined(autofs['maps']['cvmfs'])) {
-            autofs['maps']['cvmfs'] = dict(
-                'enabled', true,
-                'preserve', true,
-                'mapname', '/etc/auto.cvmfs',
-                'type', 'program',
-                'mountpoint', '/cvmfs',
-            );
-        };
-        SELF['autofs'] = autofs;
-    };
-    SELF;
-};
+prefix '/software/components/autofs/maps';
+# Do not overwrite an existing cvmfs map definition
+'cvmfs' ?= dict(
+    'enabled', true,
+    'preserve', true,
+    'mapname', '/etc/auto.cvmfs',
+    'type', 'program',
+    'mountpoint', '/cvmfs',
+);
 
 
 #

--- a/features/cvmfs/config.pan
+++ b/features/cvmfs/config.pan
@@ -1,8 +1,4 @@
 unique template features/cvmfs/config;
 
 variable CVMFS_CLIENT_ENABLED ?= false;
-include {
-    if ((is_boolean(CVMFS_CLIENT_ENABLED) && CVMFS_CLIENT_ENABLED)) {
-        'features/cvmfs/client';
-    };
-};
+include if ( CVMFS_CLIENT_ENABLED ) 'features/cvmfs/client';


### PR DESCRIPTION
- Code of previous version is broken as the test to see if autofs
was already configured doesn't work after including autofs component
- Not managing the required autofs configuration doesn't make sense
- Managing the configuration is harmless as other content in /etc/auto.master
is preserved