### PR TITLE
Add virtual EL6 QEMU CPU

### DIFF
--- a/hardware/cpu/qemu/cpu64-rhel6.pan
+++ b/hardware/cpu/qemu/cpu64-rhel6.pan
@@ -1,0 +1,8 @@
+structure template hardware/cpu/qemu/cpu64-rhel6;
+
+"manufacturer" = "Intel";
+"model" = "QEMU Virtual CPU version (cpu64-rhel6)";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 1;
+"max_threads" = 1;


### PR DESCRIPTION
Hypervisors running QEMU on EL6 provide this slightly odd model of CPU to guests running on them.