### PR TITLE
frontier squid: Fix typo in script filename

### DIFF
--- a/features/frontier/config.pan
+++ b/features/frontier/config.pan
@@ -26,7 +26,7 @@ variable FRONTIER_HOST_MONITOR_STRING ?= {
 };
 
 include 'components/filecopy/config';
-'/software/components/filecopy/services/{/etc/squid/customized.sh}' = dict(
+'/software/components/filecopy/services/{/etc/squid/customize.sh}' = dict(
     'config', format(
         file_contents('features/frontier/customized.sh.file'),
         FRONTIER_LOCAL_NET_STRING,


### PR DESCRIPTION
Resolves #128.

Thanks to @almumontiel for reporting.