### PR TITLE
Add template for NVMe devices

### DIFF
--- a/hardware/harddisk/generic/nvme.pan
+++ b/hardware/harddisk/generic/nvme.pan
@@ -1,0 +1,6 @@
+structure template hardware/harddisk/generic/nvme;
+
+"model"     = "Generic NVMe disk";
+"capacity"  = undef;
+"interface" = "nvme";
+"part_prefix" = "p";


### PR DESCRIPTION
In addition to differences in device numbering and namespaces, NVMe devices prefix partitions with `p`.

Requires quattor/template-library-core#203 to add `nvme` to the schema.