### PR TITLE
machine-types/core refactoring to make it more flexible

### DIFF
--- a/machine-types/core-init.pan
+++ b/machine-types/core-init.pan
@@ -1,0 +1,45 @@
+# This template initialises the variables related to the site, cluster and the host.
+# Factorised from core.pan to adresse use cases where some configuration is
+# needed between this part and the main part of the OS configuration.
+
+template machine-types/core-init;
+
+# Include static information and derived global variables.
+variable SITE_DB_TEMPLATE ?= 'site/databases';
+include SITE_DB_TEMPLATE;
+variable SITE_GLOBAL_VARS_TEMPLATE ?= 'site/global_variables';
+include SITE_GLOBAL_VARS_TEMPLATE;
+
+# define site functions
+variable SITE_FUNCTIONS_TEMPLATE ?= if_exists('site/functions');
+include SITE_FUNCTIONS_TEMPLATE;
+
+# Package management core functions
+include 'components/spma/functions';
+
+# profile_base for profile structure
+include 'quattor/profile_base';
+
+# hardware
+include 'hardware/functions';
+"/hardware" = if ( exists(DB_MACHINE[escape(FULL_HOSTNAME)]) ) {
+    create(DB_MACHINE[escape(FULL_HOSTNAME)]);
+} else {
+    error(FULL_HOSTNAME + " : hardware not found in machine database");
+};
+variable MACHINE_PARAMS_CONFIG ?= undef;
+include MACHINE_PARAMS_CONFIG;
+"/hardware" = if ( exists(MACHINE_PARAMS) && is_dict(MACHINE_PARAMS) ) {
+    update_hw_params();
+} else {
+    SELF;
+};
+
+
+# Cluster specific configuration
+variable CLUSTER_INFO_TEMPLATE ?= 'site/cluster_info';
+include CLUSTER_INFO_TEMPLATE;
+
+
+# Select OS version based on machine name
+include 'os/version';

--- a/machine-types/core.pan
+++ b/machine-types/core.pan
@@ -1,70 +1,38 @@
-############################################################
-#
-# template machine-types/core
-#
-# Defines bare minimum configuration (core) for a node.
-#
-# RESPONSIBLE: Christos Triantafyllidis <ctria@grid.auth.gr>
-#
-############################################################
+# This template is the core template used to configure the OS and the basic services.
 
 template machine-types/core;
 
-# Include static information and derived global variables.
-variable SITE_DB_TEMPLATE ?= if_exists('pro_site_databases');
-variable SITE_DB_TEMPLATE ?= 'site/databases';
-include { SITE_DB_TEMPLATE };
-variable SITE_GLOBAL_VARS_TEMPLATE ?= if_exists('pro_site_global_variables');
-variable SITE_GLOBAL_VARS_TEMPLATE ?= 'site/global_variables';
-include { SITE_GLOBAL_VARS_TEMPLATE };
-
-#
-# define site functions
-#
-variable SITE_FUNCTIONS_TEMPLATE ?= if_exists('site/functions');
-variable SITE_FUNCTIONS_TEMPLATE ?= if_exists('pro_site_functions');
-include { SITE_FUNCTIONS_TEMPLATE };
-
-#
-# profile_base for profile structure
-#
-include { 'quattor/profile_base' };
-
-#
-# NCM core components
-#
-include { 'components/spma/config' };
-include { 'components/grub/config' };
+# Core initializations related to host hardware, cluster and global site variables
+# Can be called before executing this template when some specific configurations
+# need to be done before configure the OS but require this initial part
+include 'machine-types/core-init';
 
 
-#
-# hardware
-#
-include { 'hardware/functions' };
-"/hardware" = if ( exists(DB_MACHINE[escape(FULL_HOSTNAME)]) ) {
-                  create(DB_MACHINE[escape(FULL_HOSTNAME)]);
-              } else {
-                  error(FULL_HOSTNAME + " : hardware not found in machine database");
-              };
-variable MACHINE_PARAMS_CONFIG ?= undef;
-include { MACHINE_PARAMS_CONFIG };
-"/hardware" = if ( exists(MACHINE_PARAMS) && is_nlist(MACHINE_PARAMS) ) {
-                update_hw_params();
-              } else {
-                SELF;
-              };
+@{
+desc = when, true, don't do the filesystem/blockdevice configuration as part of the OS configuration
+value = boolean
+default = false
+required = no
+}
+variable OS_POSTPONE_FILESYSTEM_CONFIG ?= false;
+variable DEBUG = debug('OS_POSTPONE_FILESYSTEM_CONFIG=%s', OS_POSTPONE_FILESYSTEM_CONFIG);
+
+@{
+desc = when, true, don't do the AII configuration as part of the OS configuration
+value = boolean
+default = OS_POSTPONE_FILESYSTEM_CONFIG (AII configuration must be done after the file system configuration)
+required = no
+}
+variable OS_POSTPONE_AII_CONFIG ?= OS_POSTPONE_FILESYSTEM_CONFIG;
+variable DEBUG = debug('%s: OS_POSTPONE_AII_CONFIG=%s', OS_POSTPONE_AII_CONFIG);
 
 
-# Cluster specific configuration
-variable CLUSTER_INFO_TEMPLATE ?= if_exists('pro_site_cluster_info');
-variable CLUSTER_INFO_TEMPLATE ?= 'site/cluster_info';
-include { CLUSTER_INFO_TEMPLATE };
-
+# Grub configuration module initialisation
+include 'components/grub/config';
 
 # common site machine configuration
-variable SITE_CONFIG_TEMPLATE ?= if_exists('pro_site_config');
 variable SITE_CONFIG_TEMPLATE ?= 'site/config';
-include { SITE_CONFIG_TEMPLATE };
+include SITE_CONFIG_TEMPLATE;
 
 
 # File system configuration.
@@ -75,77 +43,58 @@ variable FILESYSTEM_LAYOUT_CONFIG_SITE ?= if_exists("site/filesystems/base");
 variable FILESYSTEM_LAYOUT_CONFIG_SITE ?= error("No file system layout template defined");
 variable FILESYSTEM_CONFIG_SITE ?= 'filesystem/config';
 
-# Select OS version based on machine name
-include { 'os/version' };
-
-variable OS_TEMPLATE_NAMESPACE = true;
-
 
 # Define OS related namespaces
 variable OS_NS_ROOT = 'config/';
-variable OS_NS_OS = OS_NS_ROOT + 'os/';
-variable OS_NS_CONFIG ?= if ( is_defined(if_exists(OS_NS_ROOT+'os/base')) ) {
-                           OS_NS_ROOT + 'os/';
-                         } else {
-                           OS_NS_ROOT + 'core/';
-                         };
+variable OS_NS_OS = OS_NS_ROOT + 'core/';
+variable OS_NS_CONFIG ?= OS_NS_ROOT + 'core/';
 variable OS_NS_QUATTOR = OS_NS_ROOT + 'quattor/';
 variable OS_NS_REPOSITORY ?= 'repository/';
-#
+
 # software packages
-#
-include { 'pan/functions' };
+include 'pan/functions';
 
-#
 # Configure Bind resolver
-#
-include { 'site/named' };
+include 'site/named';
 
 
-#
 # Include OS version dependent RPMs
-#
 variable SERVICE_OS_BASE_TEMPLATE = {
-  if ( is_defined(OS_NS_CONFIG) ) {
-    OS_NS_CONFIG + "base";
-  } else {
-    undef;
-  };
+    if ( is_defined(OS_NS_CONFIG) ) {
+        OS_NS_CONFIG + "base";
+    } else {
+        undef;
+    };
 };
-include { SERVICE_OS_BASE_TEMPLATE };
+include SERVICE_OS_BASE_TEMPLATE;
 
+# Configure time synchonisation
+include if_exists('site/time_synchronisation');
 
-#
 # Quattor client software
-#
-include { 'quattor/client/config' };
+include 'quattor/client/config';
 
 
 # Configure filesystem layout.
 # Must be done after NFS initialisation as it may tweak some mount points.
-include { return(FILESYSTEM_CONFIG_SITE) };
+include if ( !OS_POSTPONE_FILESYSTEM_CONFIG ) FILESYSTEM_CONFIG_SITE;
 
 #
 # AII component must be included after much of the other setup.
 #
-include { OS_NS_QUATTOR + 'aii' };
+include if ( !OS_POSTPONE_AII_CONFIG ) OS_NS_QUATTOR + 'aii';
 
 
 #
 # Add local users if some configured
 #
 variable USER_CONFIG_INCLUDE = if ( exists(USER_CONFIG_SITE) && is_defined(USER_CONFIG_SITE) ) {
-                                 return('users/config');
-                               } else {
-                                 return(null);
-                               };
-include { USER_CONFIG_INCLUDE };
+    'users/config';
+} else {
+    null;
+};
+include USER_CONFIG_INCLUDE;
 
-#
-# Add site specific configuration if any
-#
-variable GLITE_BASE_CONFIG_SITE ?= null;
-include GLITE_BASE_CONFIG_SITE;
 
 # Default repository configuration template
 variable PKG_REPOSITORY_CONFIG ?= 'repository/config';

--- a/machine-types/frontier.pan
+++ b/machine-types/frontier.pan
@@ -1,10 +1,15 @@
 
 template machine-types/frontier;
 
+# UMD site configuration
+variable GLITE_BASE_CONFIG_SITE ?= undef;
+
 # CREATE_HOME must be defined as undef
 variable CREATE_HOME ?= undef;
 
 include 'machine-types/core';
+
+include GLITE_BASE_CONFIG_SITE;
 
 include 'features/frontier/config';
 

--- a/os/kernel_version_arch.pan
+++ b/os/kernel_version_arch.pan
@@ -6,126 +6,114 @@ variable KERNEL_VERSION_CONFIG ?= null;
 
 variable OS_ERRATA_INIT ?= 'config/os/errata/init';
 
+variable KERNEL_OS_VERSION_PARAMS ?= if ( is_defined(OS_VERSION_PARAMS) ) {
+    OS_VERSION_PARAMS;
+} else if ( is_defined(OS_VERSION_PARAMS_DEFAULT) ) {
+    OS_VERSION_PARAMS_DEFAULT;
+} else {
+    error('OS_VERSION_PARAMS undefined, unable to configure the kernel');
+};
+
+variable DEBUG = debug('KERNEL_OS_VERSION_PARAMS=%s', to_string(KERNEL_OS_VERSION_PARAMS));
+
 # Function to define architecture to use.
 # DISTRIB_ARCH is a special value translated to the architecture of the distribution
 # used on the current node. This allows to install a 32-bit OS on a 64-bit capable machine.
 # Use CPU architecture defined in CPU HW template as a last resort as it prevents running 32-bit
 # OS on a 64-bit capable CPU.
 function arch_from_cpu = {
-  if ( exists("/hardware/cpu/0/vendor") ) {
-    vendor = value("/hardware/cpu/0/vendor");
-  } else if ( exists("/hardware/cpu/0/manufacturer") ) {
-    vendor = value("/hardware/cpu/0/manufacturer");
-  };
-  if ( !exists(vendor) || !exists(CPU_VENDOR_TO_ARCH[vendor]) ) {
-    vendor = 'DEFAULT';
-  };
-  if ( exists(CPU_VENDOR_TO_ARCH[vendor]) ) {
-    arch = CPU_VENDOR_TO_ARCH[vendor];
-  } else if ( exists("/hardware/cpu/0/arch") ) {
-    arch = value("/hardware/cpu/0/arch");
-  } else {
-    arch = undef;
-  };
-
-  if ( !is_defined(arch) ) {
-    error('Unable to guess OS architecture from CPU characteristrics');
-  } else if ( arch == 'DISTRIB_ARCH' ) {
-    if ( is_defined(OS_VERSION_PARAMS['arch']) ) {
-      arch = OS_VERSION_PARAMS['arch'];
-      if ( arch == 'i386' ) {
-        # If 'athlon' is needed (SL3), must be set explicitly using variable CPU_VENDOR_TO_ARCH
-        # in OS specific template config/os/kernel_version_arch.tpl.
-        arch = 'i686';
-      };
-    } else {
-      error('Distribution architecture not found, unable to guess OS architecture used');
+    if ( exists("/hardware/cpu/0/vendor") ) {
+        vendor = value("/hardware/cpu/0/vendor");
+    } else if ( exists("/hardware/cpu/0/manufacturer") ) {
+        vendor = value("/hardware/cpu/0/manufacturer");
     };
-  };
+    if ( !exists(vendor) || !exists(CPU_VENDOR_TO_ARCH[vendor]) ) {
+        vendor = 'DEFAULT';
+    };
+    if ( exists(CPU_VENDOR_TO_ARCH[vendor]) ) {
+        arch = CPU_VENDOR_TO_ARCH[vendor];
+    } else if ( exists("/hardware/cpu/0/arch") ) {
+        arch = value("/hardware/cpu/0/arch");
+    } else {
+        arch = undef;
+    };
 
-  if ( exists("/hardware/cpu/0/arch") &&
-       (value("/hardware/cpu/0/arch") == 'i386') &&
-       !match(arch,'i686|athlon') ) {
-    error('OS architecture '+arch+' unsupported on CPU arch '+value("/hardware/cpu/0/arch"));
-  };
+    if ( !is_defined(arch) ) {
+        error('Unable to guess OS architecture from CPU characteristrics');
+    } else if ( arch == 'DISTRIB_ARCH' ) {
+        if ( is_defined(KERNEL_OS_VERSION_PARAMS['arch']) ) {
+            arch = KERNEL_OS_VERSION_PARAMS['arch'];
+            if ( arch == 'i386' ) {
+                # If 'athlon' is needed (SL3), must be set explicitly using variable CPU_VENDOR_TO_ARCH
+                # in OS specific template config/os/kernel_version_arch.tpl.
+                arch = 'i686';
+            };
+        } else {
+            error('Distribution architecture not found, unable to guess OS architecture used');
+        };
+    };
 
-  arch;
+    if ( exists("/hardware/cpu/0/arch")
+            && (value("/hardware/cpu/0/arch") == 'i386')
+            && !match(arch, 'i686|athlon') ) {
+        error('OS architecture %s unsupported on CPU arch %s', arch, value("/hardware/cpu/0/arch"));
+    };
+
+    arch;
 };
 
 
 # Include OS version specific configuration if any.
 # May redefined any of the variables define below as they are just default values.
-include { if_exists('config/os/kernel_version_arch') };
+include if_exists('config/os/kernel_version_arch');
 
 # Include specific parameters set by errata (mainly kernel version)
-include { if_exists(OS_ERRATA_INIT) };
+include if_exists(OS_ERRATA_INIT);
 
 # Define default versions for kernel based on OS version (architecture independent).
 # They will be merged with site defaults later.
-variable OS_KERNEL_VERSION_DEFAULT ?= nlist(
-  'sl307', '2.4.21-40.EL',
-  'sl308', '2.4.21-47.0.1.EL',
-  'sl440', '2.6.9-42.0.3.EL',
-  'sl450', '2.6.9-55.EL',
-  'sl460', '2.6.9-67.0.4.EL',
-  'sl470', '2.6.9-78.0.1.EL',
-  'sl510', '2.6.18-53.1.4.el5',
-  'sl520', '2.6.18-92.1.6.el5',
-  'sl530', '2.6.18-128.1.1.el5',
-  'sl540', '2.6.18-164.2.1.el5',
-  'sl550', '2.6.18-194.3.1.el5',
-  'sl560', '2.6.18-238.9.1.el5',
-  'sl570', '2.6.18-274.el5',
-  'sl580', '2.6.18-308.1.1.el5',
-  'sl600', '2.6.32-71.el6',
-  'sl610', '2.6.32-131.0.15.el6',
-  'sl620', '2.6.32-220.el6',
-  'sl630', '2.6.32-279.el6',
-  'sl640', '2.6.32-358.el6',
-  'centos550', '2.6.18-194.el5',
-  'fedora14', '2.6.35.6-45.fc14',
-  'opensuse11','2.6.34-12.3',
+variable OS_KERNEL_VERSION_DEFAULT ?= dict(
 );
 
 # Always use largesmp by default. Override in config/os/kernel_version_arch.tpl in
 # templates for the OS version if not appropriate.
-variable KERNEL_SMP_PARAMS ?= nlist(
-  'limit', 4096,
-  'largesmp', 'largesmp',
-  'smp', 'largesmp',
+variable KERNEL_SMP_PARAMS ?= dict(
+    'limit', 4096,
+    'largesmp', 'largesmp',
+    'smp', 'largesmp',
 );
 
-variable CPU_VENDOR_TO_ARCH ?= nlist(
-        "DEFAULT", "DISTRIB_ARCH",
+variable CPU_VENDOR_TO_ARCH ?= dict(
+    "DEFAULT", "DISTRIB_ARCH",
 );
 
 
 # Load OS errata initialization template and site-specific template
 # that may redefine some defaults, in particular kernel version to use.
 # OS errata may define a new kernel version to use for one (or more) OS
-# version through variable (nlist) OS_KERNEL_VERSION_ERRATA.
+# version through variable (dict) OS_KERNEL_VERSION_ERRATA.
 
 # Include only if it exists. Not supported for old OS templates (before SL 4.4).
-include { if_exists(OS_ERRATA_INIT) };
+include if_exists(OS_ERRATA_INIT);
 
 variable OS_KERNEL_VERSION_DEFAULT = {
-  if ( is_defined(OS_KERNEL_VERSION_ERRATA) ) {
-    foreach (os;kernel;OS_KERNEL_VERSION_ERRATA) {
-      SELF[os] = kernel;
+    if ( is_defined(OS_KERNEL_VERSION_ERRATA) ) {
+        foreach (os; kernel; OS_KERNEL_VERSION_ERRATA) {
+            SELF[os] = kernel;
+        };
     };
-  };
-  SELF;
+    SELF;
 };
 
-include { KERNEL_VERSION_CONFIG };
+include KERNEL_VERSION_CONFIG;
 
 variable OS_KERNEL_VERSION = {
-  foreach (os;kernel;OS_KERNEL_VERSION_DEFAULT) {
-    if ( !is_defined(SELF[os]) ) {
-      SELF[os] = kernel;
+    foreach (os; kernel; OS_KERNEL_VERSION_DEFAULT) {
+        if ( !is_defined(SELF[os]) ) {
+            SELF[os] = kernel;
+        };
     };
-  };
-  SELF;
+    SELF;
 };
 
 
@@ -141,52 +129,34 @@ variable KERNEL_EXPLICITLY_DEFINED = is_defined(KERNEL_VERSION_NUM) || is_define
 # First a match is attempted on the version+architecture, then on version only.
 # If there is no match, don't define the kernel version (probably managed  by YUM)
 variable KERNEL_VERSION_NUM ?= {
-  if ( is_defined(NODE_OS_VERSION) ) {
-    if ( is_defined(OS_KERNEL_VERSION[NODE_OS_VERSION]) ) {
-      # Kernel version specific to version+arch
-      OS_KERNEL_VERSION[NODE_OS_VERSION];
-    } else if ( is_defined(OS_VERSION_PARAMS['version']) &&
-                is_defined(OS_KERNEL_VERSION[OS_VERSION_PARAMS['version']]) ) {
-      OS_KERNEL_VERSION[OS_VERSION_PARAMS['version']];
+    if ( is_defined(NODE_OS_VERSION) ) {
+        if ( is_defined(OS_KERNEL_VERSION[NODE_OS_VERSION]) ) {
+            # Kernel version specific to version+arch
+            OS_KERNEL_VERSION[NODE_OS_VERSION];
+        } else if ( is_defined(KERNEL_OS_VERSION_PARAMS['version']) &&
+                    is_defined(OS_KERNEL_VERSION[KERNEL_OS_VERSION_PARAMS['version']]) ) {
+            OS_KERNEL_VERSION[KERNEL_OS_VERSION_PARAMS['version']];
+        } else {
+            # Variant defined but no version explicitly defined and none found in the default list
+            if ( KERNEL_EXPLICITLY_DEFINED ) {
+                error(
+                    'Kernel variant defined to %s but no default kernel version could be found for OS version %s',
+                    KERNEL_VARIANT, NODE_OS_VERSION,
+                    );
+            } else {
+                debug(
+                    'No default kernel version defined for OS version/arch %s (version=%s)',
+                    NODE_OS_VERSION,
+                    to_string(KERNEL_OS_VERSION_PARAMS['version'])
+                    );
+            };
+        };
     } else {
-      # Variant defined but no version explicitly defined and none found in the default list
-      if ( KERNEL_EXPLICITLY_DEFINED ) {
-        error('Kernel variant defined to '+KERNEL_VARIANT+' but no default kernel version could be found for OS version '+NODE_OS_VERSION);
-      } else {
-        debug('No default kernel version defined for OS version/arch '+NODE_OS_VERSION+' (version='+to_string(OS_VERSION_PARAMS['version'])+')' );
-      };
+        error('No OS version defined : unable to guess kernel version. Define variable KERNEL_VERSION_NUM.');
     };
-  } else {
-    error('No OS version defined : unable to guess kernel version. Define variable KERNEL_VERSION_NUM.');
-  };
 };
 
-# For SL4 only
-variable KERNEL_VARIANT ?= {
-  if ( is_defined(OS_VERSION_PARAMS['version']) && (OS_VERSION_PARAMS['major'] == 'sl4') ) {
-    ram_size = 0;
-    foreach (i;v;value("/hardware/ram")) {
-      if ( is_defined(v["size"]) ) {
-        ram_size = ram_size + v["size"];
-      } else {
-        error('RAM size undefined for bank '+to_string(0));
-      };
-    };
-    if ( (KERNEL_SMP_PARAMS['limit'] > 0) && (ram_size >= KERNEL_SMP_PARAMS['limit'])) {
-      debug('Memory size above the smp kernel limit. Using largesmp kernel.');
-      KERNEL_SMP_PARAMS['largesmp'];
-    } else {
-      if ( exists("/hardware/cpu/1") ) {
-        # largesmp is the default smp kernel for all 64-bit machines
-        KERNEL_SMP_PARAMS['smp'];
-      } else {
-        '';
-      };
-    };
-  } else {
-    undef;
-  };
-};
+variable KERNEL_VARIANT ?= undef;
 
 #
 # Define variables related to CPU architecture.
@@ -196,36 +166,36 @@ variable KERNEL_VARIANT ?= {
 #
 variable CPU_ARCH ?= arch_from_cpu();
 variable PKG_ARCH_DEFAULT ?= if ( match(CPU_ARCH, 'i686|athlon') ) {
-                               'i386'
-                             } else {
-                               CPU_ARCH
-                             };
+    'i386'
+} else {
+    CPU_ARCH
+};
 variable PKG_ARCH_JAVA ?= if ( PKG_ARCH_DEFAULT == 'i386' ) {
-                            'i586'
-                          } else {
-                            PKG_ARCH_DEFAULT
-                          };
+    'i586'
+} else {
+    PKG_ARCH_DEFAULT
+};
 # Hack to handle hugemem variant on SL3 which exists only as i686
 variable PKG_ARCH_KERNEL ?= if ( (CPU_ARCH == 'athlon') && (KERNE_VARIANT == 'hugemem') ) {
-                              'i686'
-                            } else {
-                              CPU_ARCH
-                            };
+    'i686'
+} else {
+    CPU_ARCH
+};
 variable PKG_ARCH_GLIBC ?= if ( CPU_ARCH == 'athlon' ) {
-                             'i686'
-                           } else {
-                             CPU_ARCH
-                           };
+    'i686'
+} else {
+    CPU_ARCH
+};
 variable PKG_ARCH_OPENSSL ?= PKG_ARCH_GLIBC;
 variable PKG_ARCH_KERNEL_MODULE_OPENAFS ?= PKG_ARCH_KERNEL;
 # Deprecated. For SL 3.05 templates compatibility
 variable PKG_ARCH_KERNEL_SMP ?= PKG_ARCH_KERNEL;
 
 variable CPU_ARCH_64BIT ?= if ( CPU_ARCH == 'x86_64' ) {
-                             true
-                           } else {
-                             false
-                           };
+    true
+} else {
+    false
+};
 
 
 # Define kernel version.
@@ -233,25 +203,25 @@ variable CPU_ARCH_64BIT ?= if ( CPU_ARCH == 'x86_64' ) {
 # other kernel related variables.
 
 variable KERNEL_VERSION = {
-  debug(OBJECT+': KERNEL_EXPLICITLY_DEFINED='+to_string(KERNEL_EXPLICITLY_DEFINED));
-  debug(OBJECT+': OS_VERSION_PARAMS='+to_string(OS_VERSION_PARAMS));
-  debug(OBJECT+': Kernel version='+to_string(KERNEL_VERSION_NUM)+', Kernel variant='+to_string(KERNEL_VARIANT));
-  if ( KERNEL_EXPLICITLY_DEFINED  || !is_defined(OS_VERSION_PARAMS['flavour']) ) {
-    if ( is_defined(KERNEL_VARIANT) ) {
-      variant = KERNEL_VARIANT;
+    debug('KERNEL_EXPLICITLY_DEFINED=%s', to_string(KERNEL_EXPLICITLY_DEFINED));
+    debug('KERNEL_OS_VERSION_PARAMS=%s', to_string(KERNEL_OS_VERSION_PARAMS));
+    debug('Kernel version=%s, Kernel variant=%s', to_string(KERNEL_VERSION_NUM), to_string(KERNEL_VARIANT));
+    if ( KERNEL_EXPLICITLY_DEFINED  || !is_defined(KERNEL_OS_VERSION_PARAMS['flavour']) ) {
+        if ( is_defined(KERNEL_VARIANT) ) {
+            variant = KERNEL_VARIANT;
+        } else {
+            variant = '';
+        };
+        version = KERNEL_VERSION_NUM + variant;
+        if ( is_defined(KERNEL_OS_VERSION_PARAMS) &&
+            match(KERNEL_OS_VERSION_PARAMS['distribution'], '^sl$') &&
+            (KERNEL_OS_VERSION_PARAMS['majorversion'] >= '6') ) {
+            version = version + '.' + PKG_ARCH_KERNEL;
+        };
+        version;
     } else {
-      variant = '';
+        undef
     };
-    version = KERNEL_VERSION_NUM + variant;
-    if ( is_defined(OS_VERSION_PARAMS) &&
-        match(OS_VERSION_PARAMS['distribution'], '^sl$') &&
-       (OS_VERSION_PARAMS['majorversion'] >= '6') ) {
-      version = version + '.' + PKG_ARCH_KERNEL;
-    };
-    version;
-  } else {
-    undef
-  };
 };
 
 # Do not define with sl5.x and sl6.x if default kernel versions are used: let yum do whatever is appropriate.
@@ -259,39 +229,39 @@ variable KERNEL_VERSION = {
 # Note: /system/kernel/version used to be defined in machine-types/xxx/base and thus
 # this value may be overwritten later in many cases... Change site templates if needed.
 
-include { if_exists('quattor/client/version') };
+include if_exists('quattor/client/version');
 '/system/kernel/version' = {
-  if ( !KERNEL_EXPLICITLY_DEFINED && is_defined(OS_VERSION_PARAMS['flavour']) ) {
-    # Consider that 14.1xx is >= 14.10 as 14.1 never existed
-    if ( is_defined(QUATTOR_RELEASE) && ((QUATTOR_RELEASE >= '15') || match(QUATTOR_RELEASE,'^14\.[189]')) ) {
-      null;
+    if ( !KERNEL_EXPLICITLY_DEFINED && is_defined(KERNEL_OS_VERSION_PARAMS['flavour']) ) {
+        # Consider that 14.1xx is >= 14.10 as 14.1 never existed
+        if ( is_defined(QUATTOR_RELEASE) && ((QUATTOR_RELEASE >= '15') || match(QUATTOR_RELEASE, '^14\.[189]')) ) {
+            null;
+        } else {
+            'YUM-managed';
+        };
     } else {
-      'YUM-managed';
+        KERNEL_VERSION;
     };
-  } else {
-    KERNEL_VERSION;
-  };
 };
 
 # Lock kernel version if using YUM-based deployment and a version has been explicitly defined
 # Variable PKG_LOCK_KERNEL_VERSION can be used to disable kernel version definition
 # even though kernel version has been explicitly defined in the configuration.
-include { 'components/spma/config' };
+include 'components/spma/config';
 variable PACKAGE_MANAGER ?= if ( exists('/software/components/spma/packager') &&
-                                 is_defined(value('/software/components/spma/packager')) ) {
-                              value('/software/components/spma/packager')
-                            } else {
-                              'spma';
-                            };
+                                is_defined(value('/software/components/spma/packager')) ) {
+    value('/software/components/spma/packager')
+} else {
+    'spma';
+};
 variable PKG_LOCK_KERNEL_VERSION ?= if ( PACKAGE_MANAGER == 'yum' ){
-                                     true;
-                                   } else {
-                                     false;
-                                   };
+    true;
+} else {
+    false;
+};
 '/software/packages' = {
-  if ( KERNEL_EXPLICITLY_DEFINED && PKG_LOCK_KERNEL_VERSION ) {
-    debug(OBJECT+': locking kernel version to '+KERNEL_VERSION_NUM);
-    pkg_repl('kernel*',KERNEL_VERSION_NUM,PKG_ARCH_KERNEL);
-  };
-  SELF;
+    if ( KERNEL_EXPLICITLY_DEFINED && PKG_LOCK_KERNEL_VERSION ) {
+        debug('locking kernel version to: %s', KERNEL_VERSION_NUM);
+        pkg_repl('kernel*', KERNEL_VERSION_NUM, PKG_ARCH_KERNEL);
+    };
+    SELF;
 };

--- a/os/version.pan
+++ b/os/version.pan
@@ -13,98 +13,102 @@ variable NODE_OS_VERSION_DEFAULT ?= undef;
 variable OS_FLAVOUR_ENABLED ?= false;
 
 # Load defaults
-include { 'os/version_db_default' };
+include 'os/version_db_default';
 
-include { debug('OS version db = '+to_string(NODE_OS_VERSION_DB)); NODE_OS_VERSION_DB };
+variable DEBUG = debug('OS version db = %s', to_string(NODE_OS_VERSION_DB));
+include NODE_OS_VERSION_DB;
 
 # Retrieve OS version for the current machine if defined
 variable NODE_OS_VERSION = if ( is_defined(NODE_OS_VERSION_DB) && is_defined(OS_VERSION[escape(FULL_HOSTNAME)]) ) {
-                             OS_VERSION[escape(FULL_HOSTNAME)];
-                           } else {
-                             if ( is_defined(NODE_OS_VERSION_DEFAULT) ) {
-                               NODE_OS_VERSION_DEFAULT;
-                             } else {
-                               # Use debug() rather than error() to
-                               # avoid breaking support for legacy OS
-                               # versions without namespace support
-                               debug('OS version undefined for '+FULL_HOSTNAME+' and no default version defined.');
-                               undef;
-                             };
-                           };
+    OS_VERSION[escape(FULL_HOSTNAME)];
+} else {
+    if ( is_defined(NODE_OS_VERSION_DEFAULT) ) {
+        NODE_OS_VERSION_DEFAULT;
+    } else {
+        # Use debug() rather than error() to
+        # avoid breaking support for legacy OS
+        # versions without namespace support
+        debug('OS version undefined for %s and no default version defined.', FULL_HOSTNAME);
+        undef;
+    };
+};
 
 # calculate OS major, minor and arch and define OS flavour if needed
-variable OS_VERSION_PARAMS ?= {
-  if ( is_string(NODE_OS_VERSION) ) {
+variable OS_VERSION_PARAMS_DEFAULT ?= {
+if ( is_string(NODE_OS_VERSION) ) {
     toks = matches(NODE_OS_VERSION, '^([a-z]+)([0-9])([0-9x]+)(?:[_\-](.*))');
     if ( length(toks) < 5 ) {
-      error('NODE_OS_VERSION ('+to_string(NODE_OS_VERSION)+') has an unexpected format. Define OS_VERSION_PARAMS explicitly');
+        error(
+            'NODE_OS_VERSION (%s) has an unexpected format. Define OS_VERSION_PARAMS_DEFAULT explicitly',
+            to_string(NODE_OS_VERSION)
+            );
     };
     SELF['distribution'] = toks[1];
     if ( match(SELF['distribution'], '^(el|centos|rhel|sl)') ) {
-      SELF['family'] = 'el';
+        SELF['family'] = 'el';
+    } else if ( match(SELF['distribution'], '^(deb)') ) {
+        SELF['family'] = 'deb';
+    } else {
+        SELF['family'] = 'undefined';
     };
     SELF['majorversion'] = toks[2];
     # Handle Fedora as a special case where there is no minor version.
     if ( SELF['distribution'] == 'fedora' ) {
-      SELF['majorversion'] = SELF['majorversion'] + toks[3];
-      toks[3] = '';
+        SELF['majorversion'] = SELF['majorversion'] + toks[3];
+        toks[3] = '';
     };
     # For backward compatibility: 'major' used to be distrib + major version
     SELF['major'] = SELF['distribution'] + SELF['majorversion'];
     # Remove trailing 0 in minor version.
-    SELF['minor'] = replace('0$','',toks[3]);
-    SELF['version'] = SELF['major']+toks[3];
+    SELF['minor'] = replace('0$', '', toks[3]);
+    SELF['version'] = SELF['major'] + toks[3];
     SELF['arch'] = toks[4];
     if ( OS_FLAVOUR_ENABLED ) {
-      SELF['flavour'] = 'x'
+        SELF['flavour'] = 'x'
     };
-    debug('OS_VERSION_PARAMS = '+to_string(SELF));
+    debug('OS_VERSION_PARAMS_DEFAULT = %', to_string(SELF));
     SELF;
-  } else {
-    debug('Cannot define OS_VERSION_PARAMS: NODE_OS_VERSION undefined');
+    } else {
+    debug('Cannot define OS_VERSION_PARAMS_DEFAULT: NODE_OS_VERSION undefined');
     undef;
-  };
+    };
 };
 
 variable OS_FLAVOUR ?= {
-    if ( is_defined(OS_VERSION_PARAMS['flavour']) ) {
-      OS_VERSION_PARAMS['major'] +"."+OS_VERSION_PARAMS['flavour']+"-"+ OS_VERSION_PARAMS['arch'];
+    if ( is_defined(OS_VERSION_PARAMS_DEFAULT['flavour']) ) {
+        OS_VERSION_PARAMS_DEFAULT['major'] + "." + OS_VERSION_PARAMS_DEFAULT['flavour']
+            + "-" + OS_VERSION_PARAMS_DEFAULT['arch'];
     } else {
-      undef;
+        undef;
     };
 };
 
 
 # Define loadpath for OS templates
 variable LOADPATH = {
-  if ( is_defined(OS_FLAVOUR) ) {
+    if ( is_defined(OS_FLAVOUR) ) {
     SELF[length(SELF)] = OS_FLAVOUR
-  } else if ( is_defined(NODE_OS_VERSION) ) {
+    } else if ( is_defined(NODE_OS_VERSION) ) {
     SELF[length(SELF)] = NODE_OS_VERSION;
-  };
-  if ( is_defined(SELF) ) {
+    };
+    if ( is_defined(SELF) ) {
     SELF;
-  } else {
+    } else {
     null;
-  };
+    };
 };
 
-# Tell other templates to use namespaces to access OS related templates
-variable OS_TEMPLATE_NAMESPACE ?= if ( is_defined(NODE_OS_VERSION) ) {
-                                   true;
-                                 } else {
-                                   false;
-                                 };
-
 # Define GLITE_CONFIG_HACKS if required by selected OS version
-variable GLITE_CONFIG_HACKS = if ( is_defined(NODE_OS_VERSION) &&
-                                   is_defined(GLITE_CONFIG_HACKS_DB[escape(NODE_OS_VERSION)]) ) {
-                                GLITE_CONFIG_HACKS_DB[escape(NODE_OS_VERSION)];
-                              } else {
-                                SELF;
-                              };
+variable GLITE_CONFIG_HACKS = {
+    if ( is_defined(NODE_OS_VERSION)
+            && is_defined(GLITE_CONFIG_HACKS_DB[escape(NODE_OS_VERSION)]) ) {
+        GLITE_CONFIG_HACKS_DB[escape(NODE_OS_VERSION)];
+    } else {
+        SELF;
+    };
+};
 
 # Add local definitions, if any
 # This can be used to do any action, even replace standard
 # definitions, if no db file is provided
-include { NODE_OS_VERSION_SITE_CONFIG };
+include NODE_OS_VERSION_SITE_CONFIG;

--- a/os/version_db_default.pan
+++ b/os/version_db_default.pan
@@ -4,11 +4,5 @@
 unique template os/version_db_default;
 
 # Deprecated starting with gLite 3.1
-variable GLITE_CONFIG_HACKS_DB ?= nlist(
-    escape("sl308-i386"), "os/pro_os_glite_postconfig",
-    escape("sl430-i386"), "os/pro_os_glite_postconfig",
-    escape("sl430-x86_64"), "os/pro_os_glite_postconfig",
-    escape("sl440-i386"), "config/glite/3.0/postconfig",
-    escape("sl440-x86_64"), "config/glite/3.0/postconfig",
-    escape("sl450-x86_64"), "config/glite/3.0/postconfig",
+variable GLITE_CONFIG_HACKS_DB ?= dict(
 );


### PR DESCRIPTION
- Initial part factored out in a separate template, core-init.pan, to allow
execution of site specific actions between this initial part and the core configuration
- Ability to delay some part of the configuration, like file systems, in case some site
information must be defined before
- Hook to configure time synchronisation according to site needs (ntp, chrony...)
- Template cleanup