### PR TITLE
support for muti options settings for logical volumes

### DIFF
--- a/filesystem/config.pan
+++ b/filesystem/config.pan
@@ -969,11 +969,16 @@ variable DISK_LV_BY_VG = {
       if ( !exists(SELF[vg_name]) ) {
         SELF[vg_name] = dict();
       };
+      options = dict();
       if ( exists(params['size']) ) {
-        SELF[vg_name][params['device']] = params['size'];
+        options['size'] = params['size'];
       } else {
         error('Size has not been specified for logical volume '+params['device']);
       };
+      if ( exists(params['raid_type'] ) ) {
+        options['raid_type'] = params['raid_type'];
+      };
+      SELF[vg_name][params['device']] = options;
     };
   };
 
@@ -984,7 +989,7 @@ variable DISK_LV_BY_VG = {
 "/system/blockdevices/logical_volumes" = {
   if ( is_defined(DISK_LV_BY_VG) ) {
     foreach (vg_name;lv_list;DISK_LV_BY_VG) {
-      lvs_add (vg_name, lv_list);
+      lvo_add (vg_name, lv_list);
     };
     SELF;
   } else {


### PR DESCRIPTION
DISK_LV_BY_VG is updated to support setting of logical volume setting, such as type. which sets the raid_type if set.
using the new function lvo_add which supports taking lv options as dict to set size and type. 

Creating raid through LVM is now possible but there appears to be no pan settings to set the logical volume type. this will provide support for this.

fixes #150