### PR TITLE
hardware/cpu/amd: adding epyc_9654

### DIFF
--- a/hardware/cpu/amd/epyc_9654.pan
+++ b/hardware/cpu/amd/epyc_9654.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/amd/epyc_9654;
+
+"manufacturer" = "AMD";
+"model" = "AMD EPYC 9654 96-Core Processor";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 96;
+"max_threads" = 192;
+"type" = "zen4"; # AMD codename
+"power" = 360; # TDP in watts


### PR DESCRIPTION
Adding a hardware file for the amd epyc 9654 CPU