### PR TITLE
Add max_threads (when missing) to defined CPUs under /shared/hardware:

### DIFF
--- a/hardware/cpu/amd/epyc_7251.pan
+++ b/hardware/cpu/amd/epyc_7251.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7251;
 "speed" = 2100; # MHz
 "arch" = "x86_64";
 "cores" = 8;
-"max_threads" = 16;
+"max_threads" = 8;
 "type" = "zen"; # AMD codename
 "power" = 120; # TDP in watts

--- a/hardware/cpu/amd/epyc_7281.pan
+++ b/hardware/cpu/amd/epyc_7281.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7281;
 "speed" = 2100; # MHz
 "arch" = "x86_64";
 "cores" = 16;
-"max_threads" = 32;
+"max_threads" = 16;
 "type" = "zen"; # AMD codename
 "power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7301.pan
+++ b/hardware/cpu/amd/epyc_7301.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7301;
 "speed" = 2200; # MHz
 "arch" = "x86_64";
 "cores" = 16;
-"max_threads" = 32;
+"max_threads" = 16;
 "type" = "zen"; # AMD codename
 "power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7302.pan
+++ b/hardware/cpu/amd/epyc_7302.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7302;
 "speed" = 3000; # MHz
 "arch" = "x86_64";
 "cores" = 16;
-"max_threads" = 32;
+"max_threads" = 16;
 "type" = "zen2"; # AMD codename
 "power" = 155; # TDP in watts

--- a/hardware/cpu/amd/epyc_7351.pan
+++ b/hardware/cpu/amd/epyc_7351.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7351;
 "speed" = 2400; # MHz
 "arch" = "x86_64";
 "cores" = 16;
-"max_threads" = 32;
+"max_threads" = 16;
 "type" = "zen"; # AMD codename
 "power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7351p.pan
+++ b/hardware/cpu/amd/epyc_7351p.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7351p;
 "speed" = 2400; # MHz
 "arch" = "x86_64";
 "cores" = 16;
-"max_threads" = 32;
+"max_threads" = 16;
 "type" = "zen"; # AMD codename
 "power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7401.pan
+++ b/hardware/cpu/amd/epyc_7401.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7401;
 "speed" = 2000; # MHz
 "arch" = "x86_64";
 "cores" = 24;
-"max_threads" = 48;
+"max_threads" = 24;
 "type" = "zen"; # AMD codename
 "power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7401p.pan
+++ b/hardware/cpu/amd/epyc_7401p.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7401p;
 "speed" = 2000; # MHz
 "arch" = "x86_64";
 "cores" = 24;
-"max_threads" = 48;
+"max_threads" = 24;
 "type" = "zen"; # AMD codename
 "power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7402.pan
+++ b/hardware/cpu/amd/epyc_7402.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7402;
 "speed" = 2800; # MHz
 "arch" = "x86_64";
 "cores" = 24;
-"max_threads" = 48;
+"max_threads" = 24;
 "type" = "zen2"; # AMD codename
 "power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7451.pan
+++ b/hardware/cpu/amd/epyc_7451.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7451;
 "speed" = 2300; # MHz
 "arch" = "x86_64";
 "cores" = 24;
-"max_threads" = 48;
+"max_threads" = 24;
 "type" = "zen"; # AMD codename
 "power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7452.pan
+++ b/hardware/cpu/amd/epyc_7452.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7452;
 "speed" = 2350; # MHz
 "arch" = "x86_64";
 "cores" = 32;
-"max_threads" = 64;
+"max_threads" = 32;
 "type" = "zen2"; # AMD codename
 "power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7501.pan
+++ b/hardware/cpu/amd/epyc_7501.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7501;
 "speed" = 2000; # MHz
 "arch" = "x86_64";
 "cores" = 32;
-"max_threads" = 64;
+"max_threads" = 32;
 "type" = "zen"; # AMD codename
 "power" = 170; # TDP in watts

--- a/hardware/cpu/amd/epyc_7502.pan
+++ b/hardware/cpu/amd/epyc_7502.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7502;
 "speed" = 2500; # MHz
 "arch" = "x86_64";
 "cores" = 32;
-"max_threads" = 64;
+"max_threads" = 32;
 "type" = "zen2"; # AMD codename
 "power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7551.pan
+++ b/hardware/cpu/amd/epyc_7551.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7551;
 "speed" = 2000; # MHz
 "arch" = "x86_64";
 "cores" = 32;
-"max_threads" = 64;
+"max_threads" = 32;
 "type" = "zen"; # AMD codename
 "power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7551p.pan
+++ b/hardware/cpu/amd/epyc_7551p.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7551p;
 "speed" = 2000; # MHz
 "arch" = "x86_64";
 "cores" = 32;
-"max_threads" = 64;
+"max_threads" = 32;
 "type" = "zen"; # AMD codename
 "power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_7601.pan
+++ b/hardware/cpu/amd/epyc_7601.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_7601;
 "speed" = 2200; # MHz
 "arch" = "x86_64";
 "cores" = 32;
-"max_threads" = 64;
+"max_threads" = 32;
 "type" = "zen"; # AMD codename
 "power" = 180; # TDP in watts

--- a/hardware/cpu/amd/epyc_9654.pan
+++ b/hardware/cpu/amd/epyc_9654.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/amd/epyc_9654;
 "speed" = 2400; # MHz
 "arch" = "x86_64";
 "cores" = 96;
-"max_threads" = 192;
+"max_threads" = 96;
 "type" = "zen4"; # AMD codename
 "power" = 360; # TDP in watts

--- a/hardware/cpu/amd/opteron_1600.pan
+++ b/hardware/cpu/amd/opteron_1600.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_1600;
 "speed"  = 1600 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_1600.pan
+++ b/hardware/cpu/amd/opteron_1600.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_1600;
 "speed"  = 1600 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_2000.pan
+++ b/hardware/cpu/amd/opteron_2000.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_2000;
 "speed"  = 2000 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_2000.pan
+++ b/hardware/cpu/amd/opteron_2000.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_2000;
 "speed"  = 2000 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_2212.pan
+++ b/hardware/cpu/amd/opteron_2212.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_2212;
 "speed" = 2000 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_2212.pan
+++ b/hardware/cpu/amd/opteron_2212.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_2212;
 "speed" = 2000 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_2214.pan
+++ b/hardware/cpu/amd/opteron_2214.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_2214;
 "speed"  = 2200 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_2214.pan
+++ b/hardware/cpu/amd/opteron_2214.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_2214;
 "speed"  = 2200 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_2216.pan
+++ b/hardware/cpu/amd/opteron_2216.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_2216;
 "speed"  = 2400 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_2216.pan
+++ b/hardware/cpu/amd/opteron_2216.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_2216;
 "speed"  = 2400 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_2218.pan
+++ b/hardware/cpu/amd/opteron_2218.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_2218;
 "speed"  = 2600 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_2218.pan
+++ b/hardware/cpu/amd/opteron_2218.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_2218;
 "speed"  = 2600 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_2350.pan
+++ b/hardware/cpu/amd/opteron_2350.pan
@@ -4,4 +4,4 @@ structure template hardware/cpu/amd/opteron_2350;
 "model"  = "AMD Opteron(TM) Opteron 2350 2.8 GHz (quad core)";
 "speed"  = 2800 * MHz;
 "cores" = 4;
-"max_threads" = 8;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_2350.pan
+++ b/hardware/cpu/amd/opteron_2350.pan
@@ -4,3 +4,4 @@ structure template hardware/cpu/amd/opteron_2350;
 "model"  = "AMD Opteron(TM) Opteron 2350 2.8 GHz (quad core)";
 "speed"  = 2800 * MHz;
 "cores" = 4;
+"max_threads" = 8;

--- a/hardware/cpu/amd/opteron_246.pan
+++ b/hardware/cpu/amd/opteron_246.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_246;
 "speed"  = 2000 * MHz;
 "arch"   = "x86_64";
 "cores"  = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/amd/opteron_246.pan
+++ b/hardware/cpu/amd/opteron_246.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_246;
 "speed"  = 2000 * MHz;
 "arch"   = "x86_64";
 "cores"  = 1;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_248.pan
+++ b/hardware/cpu/amd/opteron_248.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_248;
 "speed"  = 2200 * MHz;
 "arch"   = "x86_64";
 "cores"  = 1;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_248.pan
+++ b/hardware/cpu/amd/opteron_248.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_248;
 "speed"  = 2200 * MHz;
 "arch"   = "x86_64";
 "cores"  = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/amd/opteron_250.pan
+++ b/hardware/cpu/amd/opteron_250.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_250;
 "speed"  = 2400 * MHz;
 "arch"   = "x86_64";
 "cores"  = 1;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_250.pan
+++ b/hardware/cpu/amd/opteron_250.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_250;
 "speed"  = 2400 * MHz;
 "arch"   = "x86_64";
 "cores"  = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/amd/opteron_270.pan
+++ b/hardware/cpu/amd/opteron_270.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_270;
 "speed"  = 2000 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_270.pan
+++ b/hardware/cpu/amd/opteron_270.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_270;
 "speed"  = 2000 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_275.pan
+++ b/hardware/cpu/amd/opteron_275.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_275;
 "speed"  = 2200 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_275.pan
+++ b/hardware/cpu/amd/opteron_275.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_275;
 "speed"  = 2200 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_280.pan
+++ b/hardware/cpu/amd/opteron_280.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_280;
 "speed"  = 2400 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_280.pan
+++ b/hardware/cpu/amd/opteron_280.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_280;
 "speed"  = 2400 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_285.pan
+++ b/hardware/cpu/amd/opteron_285.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_285;
 "speed"  = 2600 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/amd/opteron_285.pan
+++ b/hardware/cpu/amd/opteron_285.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_285;
 "speed"  = 2600 * MHz;
 "arch"   = "x86_64";
 "cores"  = 2;
+"max_threads" = 4;

--- a/hardware/cpu/amd/opteron_4334.pan
+++ b/hardware/cpu/amd/opteron_4334.pan
@@ -5,4 +5,4 @@ structure template hardware/cpu/amd/opteron_4334;
 "speed"  = 3100 * MHz;
 "arch"   = "x86_64";
 "cores"  = 6;
-"max_threads" = 12;
+"max_threads" = 6;

--- a/hardware/cpu/amd/opteron_4334.pan
+++ b/hardware/cpu/amd/opteron_4334.pan
@@ -5,3 +5,4 @@ structure template hardware/cpu/amd/opteron_4334;
 "speed"  = 3100 * MHz;
 "arch"   = "x86_64";
 "cores"  = 6;
+"max_threads" = 12;

--- a/hardware/cpu/amd/opteron_6128.pan
+++ b/hardware/cpu/amd/opteron_6128.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_6128;
 "speed"  = 2000 * MHz;
 "arch"   = "x86_64";
 "cores"  = 8;
-"max_threads" = 16;
+"max_threads" = 8;

--- a/hardware/cpu/amd/opteron_6128.pan
+++ b/hardware/cpu/amd/opteron_6128.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_6128;
 "speed"  = 2000 * MHz;
 "arch"   = "x86_64";
 "cores"  = 8;
+"max_threads" = 16;

--- a/hardware/cpu/amd/opteron_6136.pan
+++ b/hardware/cpu/amd/opteron_6136.pan
@@ -4,4 +4,4 @@ structure template hardware/cpu/amd/opteron_6136;
 "model"  = "AMD Opteron(TM) Opteron 6136 2.4 GHz (octo core)";
 "speed"  = 2400 * MHz;
 "cores" = 8;
-"max_threads" = 16;
+"max_threads" = 8;

--- a/hardware/cpu/amd/opteron_6136.pan
+++ b/hardware/cpu/amd/opteron_6136.pan
@@ -4,3 +4,4 @@ structure template hardware/cpu/amd/opteron_6136;
 "model"  = "AMD Opteron(TM) Opteron 6136 2.4 GHz (octo core)";
 "speed"  = 2400 * MHz;
 "cores" = 8;
+"max_threads" = 16;

--- a/hardware/cpu/amd/opteron_6172.pan
+++ b/hardware/cpu/amd/opteron_6172.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/amd/opteron_6172;
 "speed"  = 2100 * MHz;
 "arch"   = "x86_64";
 "cores"  = 12;
+"max_threads" = 24;

--- a/hardware/cpu/amd/opteron_6172.pan
+++ b/hardware/cpu/amd/opteron_6172.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/amd/opteron_6172;
 "speed"  = 2100 * MHz;
 "arch"   = "x86_64";
 "cores"  = 12;
-"max_threads" = 24;
+"max_threads" = 12;

--- a/hardware/cpu/intel/core_duo.pan
+++ b/hardware/cpu/intel/core_duo.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/core_duo;
 "speed" = 2000 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/intel/core_duo.pan
+++ b/hardware/cpu/intel/core_duo.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/core_duo;
 "speed" = 2000 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
+"max_threads" = 4;

--- a/hardware/cpu/intel/core_duo_e8400.pan
+++ b/hardware/cpu/intel/core_duo_e8400.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/core_duo_e8400;
 "speed" = 3000 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/intel/core_duo_e8400.pan
+++ b/hardware/cpu/intel/core_duo_e8400.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/core_duo_e8400;
 "speed" = 3000 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
+"max_threads" = 4;

--- a/hardware/cpu/intel/core_duo_q6600.pan
+++ b/hardware/cpu/intel/core_duo_q6600.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/core_duo_q6600;
 "speed" = 2400 * MHz;
 "arch" = "x86_64";
 "cores" = 4;
+"max_threads" = 8;

--- a/hardware/cpu/intel/core_duo_q6600.pan
+++ b/hardware/cpu/intel/core_duo_q6600.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/core_duo_q6600;
 "speed" = 2400 * MHz;
 "arch" = "x86_64";
 "cores" = 4;
-"max_threads" = 8;
+"max_threads" = 4;

--- a/hardware/cpu/intel/pentium_1400.pan
+++ b/hardware/cpu/intel/pentium_1400.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/pentium_1400;
 "speed" = 1400 * MHz;
 "arch" = "i386";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/pentium_1400.pan
+++ b/hardware/cpu/intel/pentium_1400.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/pentium_1400;
 "speed" = 1400 * MHz;
 "arch" = "i386";
 "cores" = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/intel/pentium_2400.pan
+++ b/hardware/cpu/intel/pentium_2400.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/pentium_2400;
 "speed" = 2400 * MHz;
 "arch" = "i386";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/pentium_2400.pan
+++ b/hardware/cpu/intel/pentium_2400.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/pentium_2400;
 "speed" = 2400 * MHz;
 "arch" = "i386";
 "cores" = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/intel/pentium_2800.pan
+++ b/hardware/cpu/intel/pentium_2800.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/pentium_2800;
 "speed" = 2800 * MHz;
 "arch" = "i386";
 "cores" = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/intel/pentium_2800.pan
+++ b/hardware/cpu/intel/pentium_2800.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/pentium_2800;
 "speed" = 2800 * MHz;
 "arch" = "i386";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/pentium_866.pan
+++ b/hardware/cpu/intel/pentium_866.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/pentium_866;
 "speed" = 866 * MHz;
 "arch" = "i386";
 "cores" = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/intel/pentium_866.pan
+++ b/hardware/cpu/intel/pentium_866.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/pentium_866;
 "speed" = 866 * MHz;
 "arch" = "i386";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/pentium_d1508.pan
+++ b/hardware/cpu/intel/pentium_d1508.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/intel/pentium_d1508;
 "speed" = 2200; # MHz
 "arch" = "x86_64";
 "cores" = 2;
-"max_threads" = 4;
+"max_threads" = 2;
 "type" = "broadwell"; # Intel codename
 "power" = 25; # TDP in watts

--- a/hardware/cpu/intel/pentium_d1517.pan
+++ b/hardware/cpu/intel/pentium_d1517.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/intel/pentium_d1517;
 "speed" = 1600; # MHz
 "arch" = "x86_64";
 "cores" = 4;
-"max_threads" = 8;
+"max_threads" = 4;
 "type" = "broadwell"; # Intel codename
 "power" = 25; # TDP in watts

--- a/hardware/cpu/intel/pentium_d1519.pan
+++ b/hardware/cpu/intel/pentium_d1519.pan
@@ -5,6 +5,6 @@ structure template hardware/cpu/intel/pentium_d1519;
 "speed" = 1500; # MHz
 "arch" = "x86_64";
 "cores" = 4;
-"max_threads" = 8;
+"max_threads" = 4;
 "type" = "broadwell"; # Intel codename
 "power" = 25; # TDP in watts

--- a/hardware/cpu/intel/pentium_xeon_3000.pan
+++ b/hardware/cpu/intel/pentium_xeon_3000.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/pentium_xeon_3000;
 "speed" = 3000 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/pentium_xeon_3000.pan
+++ b/hardware/cpu/intel/pentium_xeon_3000.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/pentium_xeon_3000;
 "speed" = 3000 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/intel/pentium_xeon_3200.pan
+++ b/hardware/cpu/intel/pentium_xeon_3200.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/pentium_xeon_3200;
 "speed" = 3200 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/intel/pentium_xeon_3200.pan
+++ b/hardware/cpu/intel/pentium_xeon_3200.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/pentium_xeon_3200;
 "speed" = 3200 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/pentium_xeon_3400.pan
+++ b/hardware/cpu/intel/pentium_xeon_3400.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/pentium_xeon_3400;
 "speed" = 3400 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/intel/pentium_xeon_3400.pan
+++ b/hardware/cpu/intel/pentium_xeon_3400.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/pentium_xeon_3400;
 "speed" = 3400 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/pentium_xeon_3600.pan
+++ b/hardware/cpu/intel/pentium_xeon_3600.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/pentium_xeon_3600;
 "speed" = 3600 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
-"max_threads" = 2;
+"max_threads" = 1;

--- a/hardware/cpu/intel/pentium_xeon_3600.pan
+++ b/hardware/cpu/intel/pentium_xeon_3600.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/pentium_xeon_3600;
 "speed" = 3600 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/woodcrest_2300.pan
+++ b/hardware/cpu/intel/woodcrest_2300.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/woodcrest_2300;
 "speed" = 2300 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
+"max_threads" = 4;

--- a/hardware/cpu/intel/woodcrest_2300.pan
+++ b/hardware/cpu/intel/woodcrest_2300.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/woodcrest_2300;
 "speed" = 2300 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/intel/woodcrest_2660.pan
+++ b/hardware/cpu/intel/woodcrest_2660.pan
@@ -6,4 +6,4 @@ structure template hardware/cpu/intel/woodcrest_2660;
 "speed" = 2660 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
-"max_threads" = 4;
+"max_threads" = 2;

--- a/hardware/cpu/intel/woodcrest_2660.pan
+++ b/hardware/cpu/intel/woodcrest_2660.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/woodcrest_2660;
 "speed" = 2660 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
+"max_threads" = 4;

--- a/hardware/cpu/intel/xeon_3400.pan
+++ b/hardware/cpu/intel/xeon_3400.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/xeon_3400;
 "speed" = 3400 * MHz;
 "arch" = "x86_64";
 "cores" = 1;
+"max_threads" = 2;

--- a/hardware/cpu/intel/xeon_e3-1230.pan
+++ b/hardware/cpu/intel/xeon_e3-1230.pan
@@ -5,6 +5,7 @@ structure template hardware/cpu/intel/xeon_e3-1230;
 "speed" = 3500 * MHz;
 "arch" = "x86_64";
 "cores" = 4;
+"max_threads" = 8;
 "type" = "kaby lake"; # Intel codename
 "power" = 72; # TDP in watts
 

--- a/hardware/cpu/intel/xeon_e5-1650v2.pan
+++ b/hardware/cpu/intel/xeon_e5-1650v2.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/xeon_e5-1650v2;
 "speed" = 3500 * MHz;
 "arch" = "x86_64";
 "cores" = 6;
+"max_threads" = 12;

--- a/hardware/cpu/intel/xeon_e5110.pan
+++ b/hardware/cpu/intel/xeon_e5110.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/xeon_e5110;
 "speed" = 1600 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
+"max_threads" = 4;

--- a/hardware/cpu/intel/xeon_e5140.pan
+++ b/hardware/cpu/intel/xeon_e5140.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/xeon_e5140;
 "speed" = 2300 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
+"max_threads" = 4;

--- a/hardware/cpu/intel/xeon_e5150.pan
+++ b/hardware/cpu/intel/xeon_e5150.pan
@@ -6,3 +6,4 @@ structure template hardware/cpu/intel/xeon_e5150;
 "speed" = 2660 * MHz;
 "arch" = "x86_64";
 "cores" = 2;
+"max_threads" = 4;

--- a/hardware/cpu/intel/xeon_silver_4210.pan
+++ b/hardware/cpu/intel/xeon_silver_4210.pan
@@ -5,5 +5,6 @@ structure template hardware/cpu/intel/xeon_silver_4210;
 "speed" = 2200 * MHz;
 "arch" = "x86_64";
 "cores" = 10;
+"max_threads" = 20;
 "power" = 85; # TDP in watts
 "type" = "cascade lake";

--- a/hardware/cpu/intel/xeon_silver_4214.pan
+++ b/hardware/cpu/intel/xeon_silver_4214.pan
@@ -5,5 +5,6 @@ structure template hardware/cpu/intel/xeon_silver_4214;
 "speed" = 2200 * MHz;
 "arch" = "x86_64";
 "cores" = 12;
+"max_threads" = 24;
 "power" = 85; # TDP in watts
 "type" = "cascade lake"; # Intel codename

--- a/hardware/cpu/intel/xeon_silver_4215.pan
+++ b/hardware/cpu/intel/xeon_silver_4215.pan
@@ -5,5 +5,6 @@ structure template hardware/cpu/intel/xeon_silver_4215;
 "speed" = 2500 * MHz;
 "arch" = "x86_64";
 "cores" = 8;
+"max_threads" = 16;
 "power" = 85; # TDP in watts
 "type" = "cascade lake"; # Intel codename


### PR DESCRIPTION
We introduced this because currently, using quattor's get_num_of_cores_max_threads would return wrong values if max_threads is not defined.

This change assumes that hyperthreading is enabled.

find . -type f -exec sh -c '
if ! grep -q "\"max_threads\"\\s*=\\s*" "$1"; then
  awk '"'"'{ if ($0 ~ /\"cores\"\s*=\s*[0-9]+\s*;/) {
    cores_value = $3;
    gsub(/;$/, "", cores_value);
    print $0;
    print "\"max_threads\" = " cores_value * 2 ";"
  } else {
    print
  }}'"'"' "$1" > tmp && mv tmp "$1"
fi
' sh {} \;