### PR TITLE
ci-scripts: Indent checker only accepts a single file

### DIFF
--- a/.ci-scripts/indent
+++ b/.ci-scripts/indent
@@ -5,4 +5,4 @@ rm -f /tmp/indent.py
 wget -q https://raw.githubusercontent.com/stfc/Pan-Indenter/master/pan_indent_checker.py -O /tmp/indent.py
 chmod u+x /tmp/indent.py
 
-git diff --name-only HEAD^ | grep '\.pan$' | xargs -r /tmp/indent.py check || exit 1
+git diff --name-only HEAD^ | grep '\.pan$' | xargs -rn1 /tmp/indent.py check || exit 1


### PR DESCRIPTION
Counterpart of quattor/template-library-core#228.