### PR TITLE
hardware/cpu: Add Intel Xeon CPUs from 2018

### DIFF
--- a/hardware/cpu/intel/xeon_d_2123it.pan
+++ b/hardware/cpu/intel/xeon_d_2123it.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2123it;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2123IT CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "skylake"; # Intel codename
+"power" = 60; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2141i.pan
+++ b/hardware/cpu/intel/xeon_d_2141i.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2141i;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2141I CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2142it.pan
+++ b/hardware/cpu/intel/xeon_d_2142it.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2142it;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2142IT CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2143it.pan
+++ b/hardware/cpu/intel/xeon_d_2143it.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2143it;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2143IT CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2145nt.pan
+++ b/hardware/cpu/intel/xeon_d_2145nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2145nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2145NT CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2146nt.pan
+++ b/hardware/cpu/intel/xeon_d_2146nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2146nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2146NT CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "skylake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2161i.pan
+++ b/hardware/cpu/intel/xeon_d_2161i.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2161i;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2161I CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 90; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2163it.pan
+++ b/hardware/cpu/intel/xeon_d_2163it.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2163it;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2163IT CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 75; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2166nt.pan
+++ b/hardware/cpu/intel/xeon_d_2166nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2166nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2166NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "skylake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2173it.pan
+++ b/hardware/cpu/intel/xeon_d_2173it.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2173it;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2173IT CPU @ 1.70GHz";
+"speed" = 1700; # MHz
+"arch" = "x86_64";
+"cores" = 14;
+"max_threads" = 28;
+"type" = "skylake"; # Intel codename
+"power" = 70; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2177nt.pan
+++ b/hardware/cpu/intel/xeon_d_2177nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2177nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2177NT CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 14;
+"max_threads" = 28;
+"type" = "skylake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2183it.pan
+++ b/hardware/cpu/intel/xeon_d_2183it.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2183it;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2183IT CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 100; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2187nt.pan
+++ b/hardware/cpu/intel/xeon_d_2187nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2187nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2187NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "skylake"; # Intel codename
+"power" = 110; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2124.pan
+++ b/hardware/cpu/intel/xeon_e_2124.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2124;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2124 CPU @ 3.30GHz";
+"speed" = 3300; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2124g.pan
+++ b/hardware/cpu/intel/xeon_e_2124g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2124g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2124G CPU @ 3.40GHz";
+"speed" = 3400; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2126g.pan
+++ b/hardware/cpu/intel/xeon_e_2126g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2126g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2126G CPU @ 3.30GHz";
+"speed" = 3300; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 6;
+"type" = "coffee lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2134.pan
+++ b/hardware/cpu/intel/xeon_e_2134.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2134;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2134 CPU @ 3.50GHz";
+"speed" = 3500; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2136.pan
+++ b/hardware/cpu/intel/xeon_e_2136.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2136;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2136 CPU @ 3.30GHz";
+"speed" = 3300; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "coffee lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2144g.pan
+++ b/hardware/cpu/intel/xeon_e_2144g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2144g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2144G CPU @ 3.60GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2146g.pan
+++ b/hardware/cpu/intel/xeon_e_2146g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2146g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2146G CPU @ 3.50GHz";
+"speed" = 3500; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "coffee lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2174g.pan
+++ b/hardware/cpu/intel/xeon_e_2174g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2174g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2174G CPU @ 3.80GHz";
+"speed" = 3800; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2186g.pan
+++ b/hardware/cpu/intel/xeon_e_2186g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2186g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2186G CPU @ 3.80GHz";
+"speed" = 3800; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "coffee lake"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6138p.pan
+++ b/hardware/cpu/intel/xeon_gold_6138p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6138p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6138P CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "skylake"; # Intel codename
+"power" = 195; # TDP in watts


### PR DESCRIPTION
Generated from [Intel ARK](https://www.intel.com/content/www/us/en/ark/products/series/595/intel-xeon-processors.html#@Server).