### PR TITLE
hardware/cpu: Add/update Intel Xeon CPUs from 2019

### DIFF
--- a/hardware/cpu/intel/xeon_bronze_3204.pan
+++ b/hardware/cpu/intel/xeon_bronze_3204.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_bronze_3204;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Bronze 3204 CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 6;
+"type" = "cascade lake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1602.pan
+++ b/hardware/cpu/intel/xeon_d_1602.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1602;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1602 CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 2;
+"max_threads" = 4;
+"type" = "hewitt lake"; # Intel codename
+"power" = 27; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1622.pan
+++ b/hardware/cpu/intel/xeon_d_1622.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1622;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1622 CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "hewitt lake"; # Intel codename
+"power" = 40; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1623n.pan
+++ b/hardware/cpu/intel/xeon_d_1623n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1623n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1623N CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "hewitt lake"; # Intel codename
+"power" = 35; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1627.pan
+++ b/hardware/cpu/intel/xeon_d_1627.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1627;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1627 CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "hewitt lake"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1633n.pan
+++ b/hardware/cpu/intel/xeon_d_1633n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1633n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1633N CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "hewitt lake"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1637.pan
+++ b/hardware/cpu/intel/xeon_d_1637.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1637;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1637 CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "hewitt lake"; # Intel codename
+"power" = 55; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1649n.pan
+++ b/hardware/cpu/intel/xeon_d_1649n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1649n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1649N CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "hewitt lake"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1653n.pan
+++ b/hardware/cpu/intel/xeon_d_1653n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1653n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1653N CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "hewitt lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2224.pan
+++ b/hardware/cpu/intel/xeon_e_2224.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2224;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2224 CPU @ 3.40GHz";
+"speed" = 3400; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2224g.pan
+++ b/hardware/cpu/intel/xeon_e_2224g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2224g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2224G CPU @ 3.50GHz";
+"speed" = 3500; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2226g.pan
+++ b/hardware/cpu/intel/xeon_e_2226g.pan
@@ -1,10 +1,10 @@
-structure template hardware/cpu/intel/xeon_e_2236;
+structure template hardware/cpu/intel/xeon_e_2226g;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) E-2236 CPU @ 3.40GHz";
+"model" = "Intel(R) Xeon(R) E-2226G CPU @ 3.40GHz";
 "speed" = 3400; # MHz
 "arch" = "x86_64";
 "cores" = 6;
-"max_threads" = 12;
+"max_threads" = 6;
 "type" = "coffee lake"; # Intel codename
 "power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2234.pan
+++ b/hardware/cpu/intel/xeon_e_2234.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2234;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2234 CPU @ 3.60GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2244g.pan
+++ b/hardware/cpu/intel/xeon_e_2244g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2244g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2244G CPU @ 3.80GHz";
+"speed" = 3800; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "coffee lake"; # Intel codename
+"power" = 71; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2246g.pan
+++ b/hardware/cpu/intel/xeon_e_2246g.pan
@@ -1,8 +1,8 @@
-structure template hardware/cpu/intel/xeon_e_2236;
+structure template hardware/cpu/intel/xeon_e_2246g;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) E-2236 CPU @ 3.40GHz";
-"speed" = 3400; # MHz
+"model" = "Intel(R) Xeon(R) E-2246G CPU @ 3.60GHz";
+"speed" = 3600; # MHz
 "arch" = "x86_64";
 "cores" = 6;
 "max_threads" = 12;

--- a/hardware/cpu/intel/xeon_e_2274g.pan
+++ b/hardware/cpu/intel/xeon_e_2274g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2274g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2274G CPU @ 4.00GHz";
+"speed" = 4000; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "coffee lake"; # Intel codename
+"power" = 83; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2276g.pan
+++ b/hardware/cpu/intel/xeon_e_2276g.pan
@@ -1,8 +1,8 @@
-structure template hardware/cpu/intel/xeon_e_2236;
+structure template hardware/cpu/intel/xeon_e_2276g;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) E-2236 CPU @ 3.40GHz";
-"speed" = 3400; # MHz
+"model" = "Intel(R) Xeon(R) E-2276G CPU @ 3.80GHz";
+"speed" = 3800; # MHz
 "arch" = "x86_64";
 "cores" = 6;
 "max_threads" = 12;

--- a/hardware/cpu/intel/xeon_e_2278g.pan
+++ b/hardware/cpu/intel/xeon_e_2278g.pan
@@ -1,10 +1,10 @@
-structure template hardware/cpu/intel/xeon_e_2236;
+structure template hardware/cpu/intel/xeon_e_2278g;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) E-2236 CPU @ 3.40GHz";
+"model" = "Intel(R) Xeon(R) E-2278G CPU @ 3.40GHz";
 "speed" = 3400; # MHz
 "arch" = "x86_64";
-"cores" = 6;
-"max_threads" = 12;
+"cores" = 8;
+"max_threads" = 16;
 "type" = "coffee lake"; # Intel codename
 "power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2286g.pan
+++ b/hardware/cpu/intel/xeon_e_2286g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2286g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2286G CPU @ 4.00GHz";
+"speed" = 4000; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "coffee lake"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2288g.pan
+++ b/hardware/cpu/intel/xeon_e_2288g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2288g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2288G CPU @ 3.70GHz";
+"speed" = 3700; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "coffee lake"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5215.pan
+++ b/hardware/cpu/intel/xeon_gold_5215.pan
@@ -1,8 +1,8 @@
-structure template hardware/cpu/intel/xeon_silver_4210;
+structure template hardware/cpu/intel/xeon_gold_5215;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Silver 4210 CPU @ 2.20GHz";
-"speed" = 2200; # MHz
+"model" = "Intel(R) Xeon(R) Gold 5215 CPU @ 2.50GHz";
+"speed" = 2500; # MHz
 "arch" = "x86_64";
 "cores" = 10;
 "max_threads" = 20;

--- a/hardware/cpu/intel/xeon_gold_5215l.pan
+++ b/hardware/cpu/intel/xeon_gold_5215l.pan
@@ -1,8 +1,8 @@
-structure template hardware/cpu/intel/xeon_silver_4210;
+structure template hardware/cpu/intel/xeon_gold_5215l;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Silver 4210 CPU @ 2.20GHz";
-"speed" = 2200; # MHz
+"model" = "Intel(R) Xeon(R) Gold 5215L CPU @ 2.50GHz";
+"speed" = 2500; # MHz
 "arch" = "x86_64";
 "cores" = 10;
 "max_threads" = 20;

--- a/hardware/cpu/intel/xeon_gold_5217.pan
+++ b/hardware/cpu/intel/xeon_gold_5217.pan
@@ -1,9 +1,10 @@
 structure template hardware/cpu/intel/xeon_gold_5217;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Gold 5217 CPU @ 3.0 GHz";
+"model" = "Intel(R) Xeon(R) Gold 5217 CPU @ 3.00GHz";
 "speed" = 3000; # MHz
 "arch" = "x86_64";
 "cores" = 8;
 "max_threads" = 16;
 "type" = "cascade lake"; # Intel codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5218b.pan
+++ b/hardware/cpu/intel/xeon_gold_5218b.pan
@@ -1,7 +1,7 @@
-structure template hardware/cpu/intel/xeon_gold_5218;
+structure template hardware/cpu/intel/xeon_gold_5218b;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz";
+"model" = "Intel(R) Xeon(R) Gold 5218B CPU @ 2.30GHz";
 "speed" = 2300; # MHz
 "arch" = "x86_64";
 "cores" = 16;

--- a/hardware/cpu/intel/xeon_gold_5218n.pan
+++ b/hardware/cpu/intel/xeon_gold_5218n.pan
@@ -1,10 +1,10 @@
-structure template hardware/cpu/intel/xeon_gold_5218;
+structure template hardware/cpu/intel/xeon_gold_5218n;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz";
+"model" = "Intel(R) Xeon(R) Gold 5218N CPU @ 2.30GHz";
 "speed" = 2300; # MHz
 "arch" = "x86_64";
 "cores" = 16;
 "max_threads" = 32;
 "type" = "cascade lake"; # Intel codename
-"power" = 125; # TDP in watts
+"power" = 110; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5218t.pan
+++ b/hardware/cpu/intel/xeon_gold_5218t.pan
@@ -1,10 +1,10 @@
-structure template hardware/cpu/intel/xeon_silver_4216;
+structure template hardware/cpu/intel/xeon_gold_5218t;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Silver 4216 CPU @ 2.10GHz";
+"model" = "Intel(R) Xeon(R) Gold 5218T CPU @ 2.10GHz";
 "speed" = 2100; # MHz
 "arch" = "x86_64";
 "cores" = 16;
 "max_threads" = 32;
 "type" = "cascade lake"; # Intel codename
-"power" = 100; # TDP in watts
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5220.pan
+++ b/hardware/cpu/intel/xeon_gold_5220.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5220;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5220 CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cascade lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5220s.pan
+++ b/hardware/cpu/intel/xeon_gold_5220s.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5220s;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5220S CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cascade lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5220t.pan
+++ b/hardware/cpu/intel/xeon_gold_5220t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5220t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5220T CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cascade lake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6209u.pan
+++ b/hardware/cpu/intel/xeon_gold_6209u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6209u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6209U CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cascade lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6210u.pan
+++ b/hardware/cpu/intel/xeon_gold_6210u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6210u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6210U CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6212u.pan
+++ b/hardware/cpu/intel/xeon_gold_6212u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6212u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6212U CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6222v.pan
+++ b/hardware/cpu/intel/xeon_gold_6222v.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6222v;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6222V CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cascade lake"; # Intel codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6226.pan
+++ b/hardware/cpu/intel/xeon_gold_6226.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6226;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6226 CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "cascade lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6230.pan
+++ b/hardware/cpu/intel/xeon_gold_6230.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6230;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cascade lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6230n.pan
+++ b/hardware/cpu/intel/xeon_gold_6230n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6230n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6230N CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cascade lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6230t.pan
+++ b/hardware/cpu/intel/xeon_gold_6230t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6230t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6230T CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cascade lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6234.pan
+++ b/hardware/cpu/intel/xeon_gold_6234.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6234;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6234 CPU @ 3.30GHz";
+"speed" = 3300; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "cascade lake"; # Intel codename
+"power" = 130; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6238.pan
+++ b/hardware/cpu/intel/xeon_gold_6238.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6238;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6238 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 22;
+"max_threads" = 44;
+"type" = "cascade lake"; # Intel codename
+"power" = 140; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6238l.pan
+++ b/hardware/cpu/intel/xeon_gold_6238l.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6238l;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6238L CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 22;
+"max_threads" = 44;
+"type" = "cascade lake"; # Intel codename
+"power" = 140; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6238t.pan
+++ b/hardware/cpu/intel/xeon_gold_6238t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6238t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6238T CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 22;
+"max_threads" = 44;
+"type" = "cascade lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6240.pan
+++ b/hardware/cpu/intel/xeon_gold_6240.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6240;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6240 CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6240l.pan
+++ b/hardware/cpu/intel/xeon_gold_6240l.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6240l;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6240L CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6240y.pan
+++ b/hardware/cpu/intel/xeon_gold_6240y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6240y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6240Y CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6242.pan
+++ b/hardware/cpu/intel/xeon_gold_6242.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6242;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6242 CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6244.pan
+++ b/hardware/cpu/intel/xeon_gold_6244.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6244;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6244 CPU @ 3.60GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6246.pan
+++ b/hardware/cpu/intel/xeon_gold_6246.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6246;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6246 CPU @ 3.30GHz";
+"speed" = 3300; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "cascade lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6248.pan
+++ b/hardware/cpu/intel/xeon_gold_6248.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6248;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6252.pan
+++ b/hardware/cpu/intel/xeon_gold_6252.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6252;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6252 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6252n.pan
+++ b/hardware/cpu/intel/xeon_gold_6252n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6252n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6252N CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6254.pan
+++ b/hardware/cpu/intel/xeon_gold_6254.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6254;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6254 CPU @ 3.10GHz";
+"speed" = 3100; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cascade lake"; # Intel codename
+"power" = 200; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6262v.pan
+++ b/hardware/cpu/intel/xeon_gold_6262v.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6262v;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6262V CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 135; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8253.pan
+++ b/hardware/cpu/intel/xeon_platinum_8253.pan
@@ -1,8 +1,8 @@
-structure template hardware/cpu/intel/xeon_gold_5218;
+structure template hardware/cpu/intel/xeon_platinum_8253;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Gold 5218 CPU @ 2.30GHz";
-"speed" = 2300; # MHz
+"model" = "Intel(R) Xeon(R) Platinum 8253 CPU @ 2.20GHz";
+"speed" = 2200; # MHz
 "arch" = "x86_64";
 "cores" = 16;
 "max_threads" = 32;

--- a/hardware/cpu/intel/xeon_platinum_8256.pan
+++ b/hardware/cpu/intel/xeon_platinum_8256.pan
@@ -1,7 +1,7 @@
-structure template hardware/cpu/intel/xeon_gold_5222;
+structure template hardware/cpu/intel/xeon_platinum_8256;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Gold 5222 CPU @ 3.80GHz";
+"model" = "Intel(R) Xeon(R) Platinum 8256 CPU @ 3.80GHz";
 "speed" = 3800; # MHz
 "arch" = "x86_64";
 "cores" = 4;

--- a/hardware/cpu/intel/xeon_platinum_8260.pan
+++ b/hardware/cpu/intel/xeon_platinum_8260.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8260;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8260 CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8260l.pan
+++ b/hardware/cpu/intel/xeon_platinum_8260l.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8260l;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8260y.pan
+++ b/hardware/cpu/intel/xeon_platinum_8260y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8260y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8260Y CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8268.pan
+++ b/hardware/cpu/intel/xeon_platinum_8268.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8268;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8268 CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8270.pan
+++ b/hardware/cpu/intel/xeon_platinum_8270.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8270;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8270 CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 26;
+"max_threads" = 52;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8276.pan
+++ b/hardware/cpu/intel/xeon_platinum_8276.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8276;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8276 CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cascade lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8276l.pan
+++ b/hardware/cpu/intel/xeon_platinum_8276l.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8276l;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8276L CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cascade lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8280.pan
+++ b/hardware/cpu/intel/xeon_platinum_8280.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8280;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8280l.pan
+++ b/hardware/cpu/intel/xeon_platinum_8280l.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8280l;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8280L CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_9221.pan
+++ b/hardware/cpu/intel/xeon_platinum_9221.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_9221;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 9221 CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "cascade lake"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_9222.pan
+++ b/hardware/cpu/intel/xeon_platinum_9222.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_9222;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 9222 CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "cascade lake"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_9242.pan
+++ b/hardware/cpu/intel/xeon_platinum_9242.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_9242;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 9242 CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "cascade lake"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_9282.pan
+++ b/hardware/cpu/intel/xeon_platinum_9282.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_9282;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 9282 CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 56;
+"max_threads" = 112;
+"type" = "cascade lake"; # Intel codename
+"power" = 400; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4208.pan
+++ b/hardware/cpu/intel/xeon_silver_4208.pan
@@ -1,7 +1,7 @@
 structure template hardware/cpu/intel/xeon_silver_4208;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Silver 4208 CPU @ 2.10 GHz";
+"model" = "Intel(R) Xeon(R) Silver 4208 CPU @ 2.10GHz";
 "speed" = 2100; # MHz
 "arch" = "x86_64";
 "cores" = 8;

--- a/hardware/cpu/intel/xeon_silver_4209t.pan
+++ b/hardware/cpu/intel/xeon_silver_4209t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4209t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4209T CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "cascade lake"; # Intel codename
+"power" = 70; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4214y.pan
+++ b/hardware/cpu/intel/xeon_silver_4214y.pan
@@ -1,7 +1,7 @@
-structure template hardware/cpu/intel/xeon_silver_4214;
+structure template hardware/cpu/intel/xeon_silver_4214y;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz";
+"model" = "Intel(R) Xeon(R) Silver 4214Y CPU @ 2.20GHz";
 "speed" = 2200; # MHz
 "arch" = "x86_64";
 "cores" = 12;

--- a/hardware/cpu/intel/xeon_silver_4215.pan
+++ b/hardware/cpu/intel/xeon_silver_4215.pan
@@ -1,10 +1,10 @@
 structure template hardware/cpu/intel/xeon_silver_4215;
 
 "manufacturer" = "Intel";
-"model" = "Xeon(R) Silver 4215 CPU @ 2.50GHz";
-"speed" = 2500 * MHz;
+"model" = "Intel(R) Xeon(R) Silver 4215 CPU @ 2.50GHz";
+"speed" = 2500; # MHz
 "arch" = "x86_64";
 "cores" = 8;
 "max_threads" = 16;
-"power" = 85; # TDP in watts
 "type" = "cascade lake"; # Intel codename
+"power" = 85; # TDP in watts


### PR DESCRIPTION
Some of the existing definitions had misformatted the model string, this updates those to match the value in `/proc/cpuinfo` and `lscpu`.

Generated from [Intel ARK](https://www.intel.com/content/www/us/en/ark/products/series/595/intel-xeon-processors.html#@Server).