### PR TITLE
hardware/cpu: Add/update Intel Xeon CPUs from 2020

### DIFF
--- a/hardware/cpu/intel/xeon_bronze_3206r.pan
+++ b/hardware/cpu/intel/xeon_bronze_3206r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_bronze_3206r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Bronze 3206R CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 8;
+"type" = "cascade lake"; # Intel codename
+"power" = 85; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5218r.pan
+++ b/hardware/cpu/intel/xeon_gold_5218r.pan
@@ -1,7 +1,7 @@
 structure template hardware/cpu/intel/xeon_gold_5218r;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Gold 5218R CPU @ 2.10 GHz";
+"model" = "Intel(R) Xeon(R) Gold 5218R CPU @ 2.10GHz";
 "speed" = 2100; # MHz
 "arch" = "x86_64";
 "cores" = 20;

--- a/hardware/cpu/intel/xeon_gold_5220r.pan
+++ b/hardware/cpu/intel/xeon_gold_5220r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5220r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5220R CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5318h.pan
+++ b/hardware/cpu/intel/xeon_gold_5318h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5318h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5318H CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cooper lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5320h.pan
+++ b/hardware/cpu/intel/xeon_gold_5320h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5320h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5320H CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cooper lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6208u.pan
+++ b/hardware/cpu/intel/xeon_gold_6208u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6208u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6208U CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6226r.pan
+++ b/hardware/cpu/intel/xeon_gold_6226r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6226r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6226R CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6230r.pan
+++ b/hardware/cpu/intel/xeon_gold_6230r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6230r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6230R CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 26;
+"max_threads" = 52;
+"type" = "cascade lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6238r.pan
+++ b/hardware/cpu/intel/xeon_gold_6238r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6238r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6238R CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cascade lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6240r.pan
+++ b/hardware/cpu/intel/xeon_gold_6240r.pan
@@ -1,7 +1,7 @@
 structure template hardware/cpu/intel/xeon_gold_6240r;
 
 "manufacturer" = "Intel";
-"model" = "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40 GHz";
+"model" = "Intel(R) Xeon(R) Gold 6240R CPU @ 2.40GHz";
 "speed" = 2400; # MHz
 "arch" = "x86_64";
 "cores" = 24;

--- a/hardware/cpu/intel/xeon_gold_6242r.pan
+++ b/hardware/cpu/intel/xeon_gold_6242r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6242r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6242R CPU @ 3.10GHz";
+"speed" = 3100; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6246r.pan
+++ b/hardware/cpu/intel/xeon_gold_6246r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6246r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6246R CPU @ 3.40GHz";
+"speed" = 3400; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6248r.pan
+++ b/hardware/cpu/intel/xeon_gold_6248r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6248r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6248R CPU @ 3.00GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6250.pan
+++ b/hardware/cpu/intel/xeon_gold_6250.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6250;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6250 CPU @ 3.90GHz";
+"speed" = 3900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "cascade lake"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6250l.pan
+++ b/hardware/cpu/intel/xeon_gold_6250l.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6250l;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6250L CPU @ 3.90GHz";
+"speed" = 3900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "cascade lake"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6256.pan
+++ b/hardware/cpu/intel/xeon_gold_6256.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6256;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6256 CPU @ 3.60GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6258r.pan
+++ b/hardware/cpu/intel/xeon_gold_6258r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6258r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6258R CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cascade lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6328h.pan
+++ b/hardware/cpu/intel/xeon_gold_6328h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6328h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6328H CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "cooper lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6328hl.pan
+++ b/hardware/cpu/intel/xeon_gold_6328hl.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6328hl;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6328HL CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "cooper lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6330h.pan
+++ b/hardware/cpu/intel/xeon_gold_6330h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6330h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6330H CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cooper lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6348h.pan
+++ b/hardware/cpu/intel/xeon_gold_6348h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6348h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6348H CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cooper lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8353h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8353h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8353h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8353H CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cooper lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8354h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8354h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8354h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8354H CPU @ 3.10GHz";
+"speed" = 3100; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "cooper lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8356h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8356h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8356h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8356H CPU @ 3.90GHz";
+"speed" = 3900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "cooper lake"; # Intel codename
+"power" = 190; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8360h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8360h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8360h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8360H CPU @ 3.00GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cooper lake"; # Intel codename
+"power" = 225; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8360hl.pan
+++ b/hardware/cpu/intel/xeon_platinum_8360hl.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8360hl;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8360HL CPU @ 3.00GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "cooper lake"; # Intel codename
+"power" = 225; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8376h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8376h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8376h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8376H CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cooper lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8376hl.pan
+++ b/hardware/cpu/intel/xeon_platinum_8376hl.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8376hl;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8376HL CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cooper lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8380h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8380h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8380h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8380H CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cooper lake"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8380hl.pan
+++ b/hardware/cpu/intel/xeon_platinum_8380hl.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8380hl;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8380HL CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "cooper lake"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4210r.pan
+++ b/hardware/cpu/intel/xeon_silver_4210r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4210r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4210R CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "cascade lake"; # Intel codename
+"power" = 100; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4210t.pan
+++ b/hardware/cpu/intel/xeon_silver_4210t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4210t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4210T CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "cascade lake"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4214r.pan
+++ b/hardware/cpu/intel/xeon_silver_4214r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4214r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4214R CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "cascade lake"; # Intel codename
+"power" = 100; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4215r.pan
+++ b/hardware/cpu/intel/xeon_silver_4215r.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4215r;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4215R CPU @ 3.20GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "cascade lake"; # Intel codename
+"power" = 130; # TDP in watts


### PR DESCRIPTION
Some of the existing definitions had misformatted the model string,
this updates those to match the value in `/proc/cpuinfo` and `lscpu`.

Generated from [Intel ARK](https://www.intel.com/content/www/us/en/ark/products/series/595/intel-xeon-processors.html#@Server).