### PR TITLE
hardware/cpu: Add Intel Xeon CPUs from 2021

### DIFF
--- a/hardware/cpu/intel/xeon_e_2314.pan
+++ b/hardware/cpu/intel/xeon_e_2314.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2314;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2314 CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "rocket lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2324g.pan
+++ b/hardware/cpu/intel/xeon_e_2324g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2324g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2324G CPU @ 3.10GHz";
+"speed" = 3100; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "rocket lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2334.pan
+++ b/hardware/cpu/intel/xeon_e_2334.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2334;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2334 CPU @ 3.40GHz";
+"speed" = 3400; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "rocket lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2336.pan
+++ b/hardware/cpu/intel/xeon_e_2336.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2336;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2336 CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "rocket lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2356g.pan
+++ b/hardware/cpu/intel/xeon_e_2356g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2356g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2356G CPU @ 3.20GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "rocket lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2374g.pan
+++ b/hardware/cpu/intel/xeon_e_2374g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2374g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2374G CPU @ 3.70GHz";
+"speed" = 3700; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "rocket lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2378.pan
+++ b/hardware/cpu/intel/xeon_e_2378.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2378;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2378 CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "rocket lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2378g.pan
+++ b/hardware/cpu/intel/xeon_e_2378g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2378g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2378G CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "rocket lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2386g.pan
+++ b/hardware/cpu/intel/xeon_e_2386g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2386g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2386G CPU @ 3.50GHz";
+"speed" = 3500; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "rocket lake"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2388g.pan
+++ b/hardware/cpu/intel/xeon_e_2388g.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2388g;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2388G CPU @ 3.20GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "rocket lake"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5315y.pan
+++ b/hardware/cpu/intel/xeon_gold_5315y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5315y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5315Y CPU @ 3.20GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 140; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5317.pan
+++ b/hardware/cpu/intel/xeon_gold_5317.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5317;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5317 CPU @ 3.00GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "ice lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5318n.pan
+++ b/hardware/cpu/intel/xeon_gold_5318n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5318n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5318N CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "ice lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5318s.pan
+++ b/hardware/cpu/intel/xeon_gold_5318s.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5318s;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5318S CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "ice lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5318y.pan
+++ b/hardware/cpu/intel/xeon_gold_5318y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5318y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5318Y CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "ice lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5320.pan
+++ b/hardware/cpu/intel/xeon_gold_5320.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5320;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5320 CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 26;
+"max_threads" = 52;
+"type" = "ice lake"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5320t.pan
+++ b/hardware/cpu/intel/xeon_gold_5320t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5320t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5320T CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6312u.pan
+++ b/hardware/cpu/intel/xeon_gold_6312u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6312u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6312U CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "ice lake"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6314u.pan
+++ b/hardware/cpu/intel/xeon_gold_6314u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6314u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6314U CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6326.pan
+++ b/hardware/cpu/intel/xeon_gold_6326.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6326;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6326 CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "ice lake"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6330.pan
+++ b/hardware/cpu/intel/xeon_gold_6330.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6330;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6330 CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "ice lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6330n.pan
+++ b/hardware/cpu/intel/xeon_gold_6330n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6330n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6330N CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "ice lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6334.pan
+++ b/hardware/cpu/intel/xeon_gold_6334.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6334;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6334 CPU @ 3.60GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6336y.pan
+++ b/hardware/cpu/intel/xeon_gold_6336y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6336y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6336Y CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "ice lake"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6338.pan
+++ b/hardware/cpu/intel/xeon_gold_6338.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6338;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6338n.pan
+++ b/hardware/cpu/intel/xeon_gold_6338n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6338n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6338N CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6338t.pan
+++ b/hardware/cpu/intel/xeon_gold_6338t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6338t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6338T CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "ice lake"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6342.pan
+++ b/hardware/cpu/intel/xeon_gold_6342.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6342;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6342 CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "ice lake"; # Intel codename
+"power" = 230; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6346.pan
+++ b/hardware/cpu/intel/xeon_gold_6346.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6346;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6346 CPU @ 3.10GHz";
+"speed" = 3100; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "ice lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6348.pan
+++ b/hardware/cpu/intel/xeon_gold_6348.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6348;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6348 CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "ice lake"; # Intel codename
+"power" = 235; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6354.pan
+++ b/hardware/cpu/intel/xeon_gold_6354.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6354;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6354 CPU @ 3.00GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "ice lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8351n.pan
+++ b/hardware/cpu/intel/xeon_platinum_8351n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8351n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8351N CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 36;
+"max_threads" = 72;
+"type" = "ice lake"; # Intel codename
+"power" = 225; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8352m.pan
+++ b/hardware/cpu/intel/xeon_platinum_8352m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8352m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8352M CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8352s.pan
+++ b/hardware/cpu/intel/xeon_platinum_8352s.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8352s;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8352S CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8352v.pan
+++ b/hardware/cpu/intel/xeon_platinum_8352v.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8352v;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8352V CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 36;
+"max_threads" = 72;
+"type" = "ice lake"; # Intel codename
+"power" = 195; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8352y.pan
+++ b/hardware/cpu/intel/xeon_platinum_8352y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8352y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8352Y CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8358.pan
+++ b/hardware/cpu/intel/xeon_platinum_8358.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8358;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8358p.pan
+++ b/hardware/cpu/intel/xeon_platinum_8358p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8358p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8358P CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 240; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8360y.pan
+++ b/hardware/cpu/intel/xeon_platinum_8360y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8360y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8360Y CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 36;
+"max_threads" = 72;
+"type" = "ice lake"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8362.pan
+++ b/hardware/cpu/intel/xeon_platinum_8362.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8362;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8362 CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "ice lake"; # Intel codename
+"power" = 265; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8368.pan
+++ b/hardware/cpu/intel/xeon_platinum_8368.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8368;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8368 CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 38;
+"max_threads" = 76;
+"type" = "ice lake"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8368q.pan
+++ b/hardware/cpu/intel/xeon_platinum_8368q.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8368q;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8368Q CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 38;
+"max_threads" = 76;
+"type" = "ice lake"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8380.pan
+++ b/hardware/cpu/intel/xeon_platinum_8380.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8380;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8380 CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 40;
+"max_threads" = 80;
+"type" = "ice lake"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4309y.pan
+++ b/hardware/cpu/intel/xeon_silver_4309y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4309y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4309Y CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4310.pan
+++ b/hardware/cpu/intel/xeon_silver_4310.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4310;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4310 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "ice lake"; # Intel codename
+"power" = 120; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4310t.pan
+++ b/hardware/cpu/intel/xeon_silver_4310t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4310t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4310T CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 105; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4314.pan
+++ b/hardware/cpu/intel/xeon_silver_4314.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4314;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4314 CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "ice lake"; # Intel codename
+"power" = 135; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4316.pan
+++ b/hardware/cpu/intel/xeon_silver_4316.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4316;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4316 CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 150; # TDP in watts


### PR DESCRIPTION
Generated from [Intel ARK](https://www.intel.com/content/www/us/en/ark/products/series/595/intel-xeon-processors.html#@Server).