### PR TITLE
hardware/cpu: Add Intel Xeon CPUs from 2022

### DIFF
--- a/hardware/cpu/intel/xeon_d_1702.pan
+++ b/hardware/cpu/intel/xeon_d_1702.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1702;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1702 CPU @ 1.60GHz";
+"speed" = 1600; # MHz
+"arch" = "x86_64";
+"cores" = 2;
+"max_threads" = 4;
+"type" = "ice lake"; # Intel codename
+"power" = 25; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1712tr.pan
+++ b/hardware/cpu/intel/xeon_d_1712tr.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1712tr;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1712TR CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "ice lake"; # Intel codename
+"power" = 40; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1713nt.pan
+++ b/hardware/cpu/intel/xeon_d_1713nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1713nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1713NT CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "ice lake"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1713nte.pan
+++ b/hardware/cpu/intel/xeon_d_1713nte.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1713nte;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1713NTE CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "ice lake"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1714.pan
+++ b/hardware/cpu/intel/xeon_d_1714.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1714;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1714 CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "ice lake"; # Intel codename
+"power" = 38; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1715ter.pan
+++ b/hardware/cpu/intel/xeon_d_1715ter.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1715ter;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1715TER CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "ice lake"; # Intel codename
+"power" = 50; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1718t.pan
+++ b/hardware/cpu/intel/xeon_d_1718t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1718t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1718T CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "ice lake"; # Intel codename
+"power" = 46; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1722ne.pan
+++ b/hardware/cpu/intel/xeon_d_1722ne.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1722ne;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1722NE CPU @ 1.70GHz";
+"speed" = 1700; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "ice lake"; # Intel codename
+"power" = 36; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1726.pan
+++ b/hardware/cpu/intel/xeon_d_1726.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1726;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1726 CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "ice lake"; # Intel codename
+"power" = 70; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1731nte.pan
+++ b/hardware/cpu/intel/xeon_d_1731nte.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1731nte;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1731NTE CPU @ 1.70GHz";
+"speed" = 1700; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 45; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1732te.pan
+++ b/hardware/cpu/intel/xeon_d_1732te.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1732te;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1732TE CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 52; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1733nt.pan
+++ b/hardware/cpu/intel/xeon_d_1733nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1733nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1733NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 53; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1734nt.pan
+++ b/hardware/cpu/intel/xeon_d_1734nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1734nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1734NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 50; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1735tr.pan
+++ b/hardware/cpu/intel/xeon_d_1735tr.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1735tr;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1735TR CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 59; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1736.pan
+++ b/hardware/cpu/intel/xeon_d_1736.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1736;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1736 CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 55; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1736nt.pan
+++ b/hardware/cpu/intel/xeon_d_1736nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1736nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1736NT CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 67; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1739.pan
+++ b/hardware/cpu/intel/xeon_d_1739.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1739;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1739 CPU @ 3.00GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 83; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1746ter.pan
+++ b/hardware/cpu/intel/xeon_d_1746ter.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1746ter;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1746TER CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 67; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1747nte.pan
+++ b/hardware/cpu/intel/xeon_d_1747nte.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1747nte;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1747NTE CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1748te.pan
+++ b/hardware/cpu/intel/xeon_d_1748te.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1748te;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1748TE CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1749nt.pan
+++ b/hardware/cpu/intel/xeon_d_1749nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1749nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1749NT CPU @ 3.00GHz";
+"speed" = 3000; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 90; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2712t.pan
+++ b/hardware/cpu/intel/xeon_d_2712t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2712t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2712T CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "ice lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2733nt.pan
+++ b/hardware/cpu/intel/xeon_d_2733nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2733nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2733NT CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2738.pan
+++ b/hardware/cpu/intel/xeon_d_2738.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2738;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2738 CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 88; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2745nx.pan
+++ b/hardware/cpu/intel/xeon_d_2745nx.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2745nx;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2745NX CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 96; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2752nte.pan
+++ b/hardware/cpu/intel/xeon_d_2752nte.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2752nte;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2752NTE CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "ice lake"; # Intel codename
+"power" = 84; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2752ter.pan
+++ b/hardware/cpu/intel/xeon_d_2752ter.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2752ter;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2752TER CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "ice lake"; # Intel codename
+"power" = 77; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2753nt.pan
+++ b/hardware/cpu/intel/xeon_d_2753nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2753nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2753NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "ice lake"; # Intel codename
+"power" = 87; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2757nx.pan
+++ b/hardware/cpu/intel/xeon_d_2757nx.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2757nx;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2757NX CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "ice lake"; # Intel codename
+"power" = 107; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2766nt.pan
+++ b/hardware/cpu/intel/xeon_d_2766nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2766nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2766NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 14;
+"max_threads" = 28;
+"type" = "ice lake"; # Intel codename
+"power" = 97; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2775te.pan
+++ b/hardware/cpu/intel/xeon_d_2775te.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2775te;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2775TE CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "ice lake"; # Intel codename
+"power" = 100; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2776nt.pan
+++ b/hardware/cpu/intel/xeon_d_2776nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2776nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2776NT CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "ice lake"; # Intel codename
+"power" = 117; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2777nx.pan
+++ b/hardware/cpu/intel/xeon_d_2777nx.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2777nx;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2777NX CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "ice lake"; # Intel codename
+"power" = 116; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2779.pan
+++ b/hardware/cpu/intel/xeon_d_2779.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2779;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2779 CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "ice lake"; # Intel codename
+"power" = 126; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2786nte.pan
+++ b/hardware/cpu/intel/xeon_d_2786nte.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2786nte;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2786NTE CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "ice lake"; # Intel codename
+"power" = 118; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2795nt.pan
+++ b/hardware/cpu/intel/xeon_d_2795nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2795nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2795NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 110; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2796nt.pan
+++ b/hardware/cpu/intel/xeon_d_2796nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2796nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2796NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 120; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2796te.pan
+++ b/hardware/cpu/intel/xeon_d_2796te.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2796te;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2796TE CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 118; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2798nt.pan
+++ b/hardware/cpu/intel/xeon_d_2798nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2798nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2798NT CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2798nx.pan
+++ b/hardware/cpu/intel/xeon_d_2798nx.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2798nx;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2798NX CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 126; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2799.pan
+++ b/hardware/cpu/intel/xeon_d_2799.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2799;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2799 CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 129; # TDP in watts


### PR DESCRIPTION
Generated from [Intel ARK](https://www.intel.com/content/www/us/en/ark/products/series/595/intel-xeon-processors.html#@Server).