### PR TITLE
hardware/cpu: Add Intel Xeon CPUs from 2023

### DIFF
--- a/hardware/cpu/intel/xeon_9460.pan
+++ b/hardware/cpu/intel/xeon_9460.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_9460;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU Max 9460 @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 40;
+"max_threads" = 80;
+"type" = "sapphire rapids hbm"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_9462.pan
+++ b/hardware/cpu/intel/xeon_9462.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_9462;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU Max 9462 @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids hbm"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_9468.pan
+++ b/hardware/cpu/intel/xeon_9468.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_9468;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU Max 9468 @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "sapphire rapids hbm"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_9470.pan
+++ b/hardware/cpu/intel/xeon_9470.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_9470;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU Max 9470 @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 52;
+"max_threads" = 104;
+"type" = "sapphire rapids hbm"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_9480.pan
+++ b/hardware/cpu/intel/xeon_9480.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_9480;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) CPU Max 9480 @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 56;
+"max_threads" = 112;
+"type" = "sapphire rapids hbm"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_bronze_3408u.pan
+++ b/hardware/cpu/intel/xeon_bronze_3408u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_bronze_3408u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Bronze 3408U CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 8;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_bronze_3508u.pan
+++ b/hardware/cpu/intel/xeon_bronze_3508u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_bronze_3508u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Bronze 3508U CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 8;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1813nt.pan
+++ b/hardware/cpu/intel/xeon_d_1813nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1813nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1813NT CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "ice lake"; # Intel codename
+"power" = 42; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1823nt.pan
+++ b/hardware/cpu/intel/xeon_d_1823nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1823nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1823NT CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "ice lake"; # Intel codename
+"power" = 55; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1834.pan
+++ b/hardware/cpu/intel/xeon_d_1834.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1834;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1834 CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 42; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1844nt.pan
+++ b/hardware/cpu/intel/xeon_d_1844nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1844nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1844NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 55; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1846.pan
+++ b/hardware/cpu/intel/xeon_d_1846.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1846;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1846 CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 55; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_1848ter.pan
+++ b/hardware/cpu/intel/xeon_d_1848ter.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_1848ter;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-1848TER CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 57; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2832nt.pan
+++ b/hardware/cpu/intel/xeon_d_2832nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2832nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2832NT CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "ice lake"; # Intel codename
+"power" = 70; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2843nt.pan
+++ b/hardware/cpu/intel/xeon_d_2843nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2843nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2843NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "ice lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2876nt.pan
+++ b/hardware/cpu/intel/xeon_d_2876nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2876nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2876NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "ice lake"; # Intel codename
+"power" = 100; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2896nt.pan
+++ b/hardware/cpu/intel/xeon_d_2896nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2896nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2896NT CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 117; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2896ter.pan
+++ b/hardware/cpu/intel/xeon_d_2896ter.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2896ter;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2896TER CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "ice lake"; # Intel codename
+"power" = 110; # TDP in watts

--- a/hardware/cpu/intel/xeon_d_2899nt.pan
+++ b/hardware/cpu/intel/xeon_d_2899nt.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_d_2899nt;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) D-2899NT CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 22;
+"max_threads" = 44;
+"type" = "ice lake"; # Intel codename
+"power" = 135; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2414.pan
+++ b/hardware/cpu/intel/xeon_e_2414.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2414;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2414 CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 4;
+"type" = "raptor lake"; # Intel codename
+"power" = 55; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2434.pan
+++ b/hardware/cpu/intel/xeon_e_2434.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2434;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2434 CPU @ 3.40GHz";
+"speed" = 3400; # MHz
+"arch" = "x86_64";
+"cores" = 4;
+"max_threads" = 8;
+"type" = "raptor lake"; # Intel codename
+"power" = 55; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2436.pan
+++ b/hardware/cpu/intel/xeon_e_2436.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2436;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2436 CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "raptor lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2456.pan
+++ b/hardware/cpu/intel/xeon_e_2456.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2456;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2456 CPU @ 3.30GHz";
+"speed" = 3300; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "raptor lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2468.pan
+++ b/hardware/cpu/intel/xeon_e_2468.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2468;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2468 CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "raptor lake"; # Intel codename
+"power" = 65; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2478.pan
+++ b/hardware/cpu/intel/xeon_e_2478.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2478;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2478 CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "raptor lake"; # Intel codename
+"power" = 80; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2486.pan
+++ b/hardware/cpu/intel/xeon_e_2486.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2486;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2486 CPU @ 3.50GHz";
+"speed" = 3500; # MHz
+"arch" = "x86_64";
+"cores" = 6;
+"max_threads" = 12;
+"type" = "raptor lake"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_e_2488.pan
+++ b/hardware/cpu/intel/xeon_e_2488.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_e_2488;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) E-2488 CPU @ 3.20GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "raptor lake"; # Intel codename
+"power" = 95; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5403n.pan
+++ b/hardware/cpu/intel/xeon_gold_5403n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5403n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5403N CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "sapphire rapids edge enhanced"; # Intel codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5411n.pan
+++ b/hardware/cpu/intel/xeon_gold_5411n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5411n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5411N CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5412u.pan
+++ b/hardware/cpu/intel/xeon_gold_5412u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5412u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5412U CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5415+.pan
+++ b/hardware/cpu/intel/xeon_gold_5415+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5415+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5415+ CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5416s.pan
+++ b/hardware/cpu/intel/xeon_gold_5416s.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5416s;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5416S CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5418n.pan
+++ b/hardware/cpu/intel/xeon_gold_5418n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5418n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5418N CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5418y.pan
+++ b/hardware/cpu/intel/xeon_gold_5418y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5418y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5418Y CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5420+.pan
+++ b/hardware/cpu/intel/xeon_gold_5420+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5420+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5420+ CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5423n.pan
+++ b/hardware/cpu/intel/xeon_gold_5423n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5423n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5423N CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "sapphire rapids edge enhanced"; # Intel codename
+"power" = 145; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5433n.pan
+++ b/hardware/cpu/intel/xeon_gold_5433n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5433n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5433N CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "sapphire rapids edge enhanced"; # Intel codename
+"power" = 160; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5512u.pan
+++ b/hardware/cpu/intel/xeon_gold_5512u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5512u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5512U CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "emerald rapids"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5515+.pan
+++ b/hardware/cpu/intel/xeon_gold_5515+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5515+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5515+ CPU @ 3.20GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "emerald rapids"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_5520+.pan
+++ b/hardware/cpu/intel/xeon_gold_5520+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_5520+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 5520+ CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "emerald rapids"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6403n.pan
+++ b/hardware/cpu/intel/xeon_gold_6403n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6403n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6403N CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "sapphire rapids edge enhanced"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6414u.pan
+++ b/hardware/cpu/intel/xeon_gold_6414u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6414u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6414U CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6416h.pan
+++ b/hardware/cpu/intel/xeon_gold_6416h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6416h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6416H CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 18;
+"max_threads" = 36;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6418h.pan
+++ b/hardware/cpu/intel/xeon_gold_6418h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6418h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6418H CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6421n.pan
+++ b/hardware/cpu/intel/xeon_gold_6421n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6421n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6421N CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6423n.pan
+++ b/hardware/cpu/intel/xeon_gold_6423n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6423n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6423N CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "sapphire rapids edge enhanced"; # Intel codename
+"power" = 195; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6426y.pan
+++ b/hardware/cpu/intel/xeon_gold_6426y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6426y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6426Y CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6428n.pan
+++ b/hardware/cpu/intel/xeon_gold_6428n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6428n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6428N CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 185; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6430.pan
+++ b/hardware/cpu/intel/xeon_gold_6430.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6430;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6430 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6433n.pan
+++ b/hardware/cpu/intel/xeon_gold_6433n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6433n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6433N CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids edge enhanced"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6433ne.pan
+++ b/hardware/cpu/intel/xeon_gold_6433ne.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6433ne;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6433NE CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids edge enhanced"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6434.pan
+++ b/hardware/cpu/intel/xeon_gold_6434.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6434;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6434 CPU @ 3.70GHz";
+"speed" = 3700; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 195; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6434h.pan
+++ b/hardware/cpu/intel/xeon_gold_6434h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6434h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6434H CPU @ 3.70GHz";
+"speed" = 3700; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 195; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6438m.pan
+++ b/hardware/cpu/intel/xeon_gold_6438m.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6438m;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6438M CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6438n.pan
+++ b/hardware/cpu/intel/xeon_gold_6438n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6438n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6438N CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6438y+.pan
+++ b/hardware/cpu/intel/xeon_gold_6438y+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6438y+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6438Y+ CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6442y.pan
+++ b/hardware/cpu/intel/xeon_gold_6442y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6442y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6442Y CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 225; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6443n.pan
+++ b/hardware/cpu/intel/xeon_gold_6443n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6443n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6443N CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids edge enhanced"; # Intel codename
+"power" = 195; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6444y.pan
+++ b/hardware/cpu/intel/xeon_gold_6444y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6444y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6444Y CPU @ 3.60GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6448h.pan
+++ b/hardware/cpu/intel/xeon_gold_6448h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6448h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6448H CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6448y.pan
+++ b/hardware/cpu/intel/xeon_gold_6448y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6448y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6448Y CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 225; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6454s.pan
+++ b/hardware/cpu/intel/xeon_gold_6454s.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6454s;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6454S CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6458q.pan
+++ b/hardware/cpu/intel/xeon_gold_6458q.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6458q;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6458Q CPU @ 3.10GHz";
+"speed" = 3100; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6526y.pan
+++ b/hardware/cpu/intel/xeon_gold_6526y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6526y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6526Y CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "emerald rapids"; # Intel codename
+"power" = 195; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6530.pan
+++ b/hardware/cpu/intel/xeon_gold_6530.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6530;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6530 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "emerald rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6534.pan
+++ b/hardware/cpu/intel/xeon_gold_6534.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6534;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6534 CPU @ 3.90GHz";
+"speed" = 3900; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "emerald rapids"; # Intel codename
+"power" = 195; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6538n.pan
+++ b/hardware/cpu/intel/xeon_gold_6538n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6538n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6538N CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "emerald rapids"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6538y+.pan
+++ b/hardware/cpu/intel/xeon_gold_6538y+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6538y+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6538Y+ CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "emerald rapids"; # Intel codename
+"power" = 225; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6542y.pan
+++ b/hardware/cpu/intel/xeon_gold_6542y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6542y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6542Y CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "emerald rapids"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6544y.pan
+++ b/hardware/cpu/intel/xeon_gold_6544y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6544y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6544Y CPU @ 3.60GHz";
+"speed" = 3600; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "emerald rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6548n.pan
+++ b/hardware/cpu/intel/xeon_gold_6548n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6548n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6548N CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "emerald rapids"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6548y+.pan
+++ b/hardware/cpu/intel/xeon_gold_6548y+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6548y+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6548Y+ CPU @ 2.50GHz";
+"speed" = 2500; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "emerald rapids"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6554s.pan
+++ b/hardware/cpu/intel/xeon_gold_6554s.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6554s;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6554S CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 36;
+"max_threads" = 72;
+"type" = "emerald rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_gold_6558q.pan
+++ b/hardware/cpu/intel/xeon_gold_6558q.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_gold_6558q;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Gold 6558Q CPU @ 3.20GHz";
+"speed" = 3200; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "emerald rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8444h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8444h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8444h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8444H CPU @ 2.90GHz";
+"speed" = 2900; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8450h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8450h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8450h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8450H CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 28;
+"max_threads" = 56;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8452y.pan
+++ b/hardware/cpu/intel/xeon_platinum_8452y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8452y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8452Y CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 36;
+"max_threads" = 72;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8454h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8454h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8454h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8454H CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8458p.pan
+++ b/hardware/cpu/intel/xeon_platinum_8458p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8458p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8458P CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 44;
+"max_threads" = 88;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8460h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8460h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8460h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8460H CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 40;
+"max_threads" = 80;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 330; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8460y+.pan
+++ b/hardware/cpu/intel/xeon_platinum_8460y+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8460y+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8460Y+ CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 40;
+"max_threads" = 80;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8461v.pan
+++ b/hardware/cpu/intel/xeon_platinum_8461v.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8461v;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8461V CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8462y+.pan
+++ b/hardware/cpu/intel/xeon_platinum_8462y+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8462y+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8462Y+ CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8468.pan
+++ b/hardware/cpu/intel/xeon_platinum_8468.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8468;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8468 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8468h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8468h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8468h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8468H CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 330; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8468v.pan
+++ b/hardware/cpu/intel/xeon_platinum_8468v.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8468v;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8468V CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 330; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8470.pan
+++ b/hardware/cpu/intel/xeon_platinum_8470.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8470;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8470 CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 52;
+"max_threads" = 104;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8470n.pan
+++ b/hardware/cpu/intel/xeon_platinum_8470n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8470n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8470N CPU @ 1.70GHz";
+"speed" = 1700; # MHz
+"arch" = "x86_64";
+"cores" = 52;
+"max_threads" = 104;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8470q.pan
+++ b/hardware/cpu/intel/xeon_platinum_8470q.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8470q;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8470Q CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 52;
+"max_threads" = 104;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8471n.pan
+++ b/hardware/cpu/intel/xeon_platinum_8471n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8471n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8471N CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 52;
+"max_threads" = 104;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8480+.pan
+++ b/hardware/cpu/intel/xeon_platinum_8480+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8480+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8480+ CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 56;
+"max_threads" = 112;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8490h.pan
+++ b/hardware/cpu/intel/xeon_platinum_8490h.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8490h;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8490H CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 60;
+"max_threads" = 120;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8558.pan
+++ b/hardware/cpu/intel/xeon_platinum_8558.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8558;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8558 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "emerald rapids"; # Intel codename
+"power" = 330; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8558p.pan
+++ b/hardware/cpu/intel/xeon_platinum_8558p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8558p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8558P CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "emerald rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8558u.pan
+++ b/hardware/cpu/intel/xeon_platinum_8558u.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8558u;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8558U CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "emerald rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8562y+.pan
+++ b/hardware/cpu/intel/xeon_platinum_8562y+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8562y+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8562Y+ CPU @ 2.80GHz";
+"speed" = 2800; # MHz
+"arch" = "x86_64";
+"cores" = 32;
+"max_threads" = 64;
+"type" = "emerald rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8568y+.pan
+++ b/hardware/cpu/intel/xeon_platinum_8568y+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8568y+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8568Y+ CPU @ 2.30GHz";
+"speed" = 2300; # MHz
+"arch" = "x86_64";
+"cores" = 48;
+"max_threads" = 96;
+"type" = "emerald rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8570.pan
+++ b/hardware/cpu/intel/xeon_platinum_8570.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8570;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8570 CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 56;
+"max_threads" = 112;
+"type" = "emerald rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8571n.pan
+++ b/hardware/cpu/intel/xeon_platinum_8571n.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8571n;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8571N CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 52;
+"max_threads" = 104;
+"type" = "emerald rapids"; # Intel codename
+"power" = 300; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8580.pan
+++ b/hardware/cpu/intel/xeon_platinum_8580.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8580;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8580 CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 60;
+"max_threads" = 120;
+"type" = "emerald rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8581v.pan
+++ b/hardware/cpu/intel/xeon_platinum_8581v.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8581v;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8581V CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 60;
+"max_threads" = 120;
+"type" = "emerald rapids"; # Intel codename
+"power" = 270; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8592+.pan
+++ b/hardware/cpu/intel/xeon_platinum_8592+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8592+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8592+ CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 64;
+"max_threads" = 128;
+"type" = "emerald rapids"; # Intel codename
+"power" = 350; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8592v.pan
+++ b/hardware/cpu/intel/xeon_platinum_8592v.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8592v;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8592V CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 64;
+"max_threads" = 128;
+"type" = "emerald rapids"; # Intel codename
+"power" = 330; # TDP in watts

--- a/hardware/cpu/intel/xeon_platinum_8593q.pan
+++ b/hardware/cpu/intel/xeon_platinum_8593q.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_platinum_8593q;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Platinum 8593Q CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 64;
+"max_threads" = 128;
+"type" = "emerald rapids"; # Intel codename
+"power" = 385; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4410t.pan
+++ b/hardware/cpu/intel/xeon_silver_4410t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4410t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4410T CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 10;
+"max_threads" = 20;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4410y.pan
+++ b/hardware/cpu/intel/xeon_silver_4410y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4410y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4410Y CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4416+.pan
+++ b/hardware/cpu/intel/xeon_silver_4416+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4416+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4416+ CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 20;
+"max_threads" = 40;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 165; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4509y.pan
+++ b/hardware/cpu/intel/xeon_silver_4509y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4509y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4509Y CPU @ 2.60GHz";
+"speed" = 2600; # MHz
+"arch" = "x86_64";
+"cores" = 8;
+"max_threads" = 16;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 125; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4510.pan
+++ b/hardware/cpu/intel/xeon_silver_4510.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4510;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4510 CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4510t.pan
+++ b/hardware/cpu/intel/xeon_silver_4510t.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4510t;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4510T CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 12;
+"max_threads" = 24;
+"type" = "sapphire rapids"; # Intel codename
+"power" = 115; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4514y.pan
+++ b/hardware/cpu/intel/xeon_silver_4514y.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4514y;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4514Y CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 16;
+"max_threads" = 32;
+"type" = "emerald rapids"; # Intel codename
+"power" = 150; # TDP in watts

--- a/hardware/cpu/intel/xeon_silver_4516y+.pan
+++ b/hardware/cpu/intel/xeon_silver_4516y+.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_silver_4516y+;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) Silver 4516Y+ CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 24;
+"max_threads" = 48;
+"type" = "emerald rapids"; # Intel codename
+"power" = 185; # TDP in watts


### PR DESCRIPTION
Generated from [Intel ARK](https://www.intel.com/content/www/us/en/ark/products/series/595/intel-xeon-processors.html#@Server).