### PR TITLE
hardware/cpu: Add Intel Xeon CPUs from 2024

### DIFF
--- a/hardware/cpu/intel/xeon_6710e.pan
+++ b/hardware/cpu/intel/xeon_6710e.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6710e;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6710E CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 64;
+"max_threads" = 64;
+"type" = "sierra forest"; # Intel codename
+"power" = 205; # TDP in watts

--- a/hardware/cpu/intel/xeon_6731e.pan
+++ b/hardware/cpu/intel/xeon_6731e.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6731e;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6731E CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 96;
+"max_threads" = 96;
+"type" = "sierra forest"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_6740e.pan
+++ b/hardware/cpu/intel/xeon_6740e.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6740e;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6740E CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 96;
+"max_threads" = 96;
+"type" = "sierra forest"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_6746e.pan
+++ b/hardware/cpu/intel/xeon_6746e.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6746e;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6746E CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 112;
+"max_threads" = 112;
+"type" = "sierra forest"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_6756e.pan
+++ b/hardware/cpu/intel/xeon_6756e.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6756e;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6756E CPU @ 1.80GHz";
+"speed" = 1800; # MHz
+"arch" = "x86_64";
+"cores" = 128;
+"max_threads" = 128;
+"type" = "sierra forest"; # Intel codename
+"power" = 225; # TDP in watts

--- a/hardware/cpu/intel/xeon_6766e.pan
+++ b/hardware/cpu/intel/xeon_6766e.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6766e;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6766E CPU @ 1.90GHz";
+"speed" = 1900; # MHz
+"arch" = "x86_64";
+"cores" = 144;
+"max_threads" = 144;
+"type" = "sierra forest"; # Intel codename
+"power" = 250; # TDP in watts

--- a/hardware/cpu/intel/xeon_6780e.pan
+++ b/hardware/cpu/intel/xeon_6780e.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6780e;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6780E CPU @ 2.20GHz";
+"speed" = 2200; # MHz
+"arch" = "x86_64";
+"cores" = 144;
+"max_threads" = 144;
+"type" = "sierra forest"; # Intel codename
+"power" = 330; # TDP in watts

--- a/hardware/cpu/intel/xeon_6952p.pan
+++ b/hardware/cpu/intel/xeon_6952p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6952p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6952P CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 96;
+"max_threads" = 192;
+"type" = "granite rapids"; # Intel codename
+"power" = 400; # TDP in watts

--- a/hardware/cpu/intel/xeon_6960p.pan
+++ b/hardware/cpu/intel/xeon_6960p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6960p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6960P CPU @ 2.70GHz";
+"speed" = 2700; # MHz
+"arch" = "x86_64";
+"cores" = 72;
+"max_threads" = 144;
+"type" = "granite rapids"; # Intel codename
+"power" = 500; # TDP in watts

--- a/hardware/cpu/intel/xeon_6972p.pan
+++ b/hardware/cpu/intel/xeon_6972p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6972p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6972P CPU @ 2.40GHz";
+"speed" = 2400; # MHz
+"arch" = "x86_64";
+"cores" = 96;
+"max_threads" = 192;
+"type" = "granite rapids"; # Intel codename
+"power" = 500; # TDP in watts

--- a/hardware/cpu/intel/xeon_6979p.pan
+++ b/hardware/cpu/intel/xeon_6979p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6979p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6979P CPU @ 2.10GHz";
+"speed" = 2100; # MHz
+"arch" = "x86_64";
+"cores" = 120;
+"max_threads" = 240;
+"type" = "granite rapids"; # Intel codename
+"power" = 500; # TDP in watts

--- a/hardware/cpu/intel/xeon_6980p.pan
+++ b/hardware/cpu/intel/xeon_6980p.pan
@@ -1,0 +1,10 @@
+structure template hardware/cpu/intel/xeon_6980p;
+
+"manufacturer" = "Intel";
+"model" = "Intel(R) Xeon(R) 6980P CPU @ 2.00GHz";
+"speed" = 2000; # MHz
+"arch" = "x86_64";
+"cores" = 128;
+"max_threads" = 256;
+"type" = "granite rapids"; # Intel codename
+"power" = 500; # TDP in watts


### PR DESCRIPTION
Generated from [Intel ARK](https://www.intel.com/content/www/us/en/ark/products/series/595/intel-xeon-processors.html#@Server).