### PR TITLE
Add test-templates to workflow 

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -9,3 +9,12 @@ jobs:
 
   standard-pan:
     uses: quattor/release/.github/workflows/pan-template-tests.yaml@main
+
+  test-templates:
+    runs-on: ubuntu-latest
+    container: ghcr.io/quattor/quattor-test-container:latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: test templates
+      run: .ci-scripts/test-templates


### PR DESCRIPTION
This appears to have never been enabled and seems to be broken.

Based on and requires #177.